### PR TITLE
Allow disabling access to the DB and the Teams API.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,14 +20,14 @@ var (
 	configMapName  spec.NamespacedName
 	OutOfCluster   bool
 	noTeamsAPI bool
-	noDBAccess bool
+	noDatabaseAccess bool
 	version        string
 )
 
 func init() {
 	flag.StringVar(&KubeConfigFile, "kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
 	flag.BoolVar(&OutOfCluster, "outofcluster", false, "Whether the operator runs in- our outside of the Kubernetes cluster.")
-	flag.BoolVar(&noDBAccess, "nodatabaseaccess", false, "Disable all access to the database from the operator side.")
+	flag.BoolVar(&noDatabaseAccess, "nodatabaseaccess", false, "Disable all access to the database from the operator side.")
 	flag.BoolVar(&noTeamsAPI, "noteamsapi", false, "Disable all access to the teams API")
 	flag.Parse()
 
@@ -91,8 +91,8 @@ func main() {
 	if configMapData["namespace"] == "" { // Namespace in ConfigMap has priority over env var
 		configMapData["namespace"] = podNamespace
 	}
-	if noDBAccess {
-		configMapData["enable_db_access"] = "false"
+	if noDatabaseAccess {
+		configMapData["enable_database_access"] = "false"
 	}
 	if noTeamsAPI {
 		configMapData["enable_teams_api"] = "false"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,12 +19,16 @@ var (
 	podNamespace   string
 	configMapName  spec.NamespacedName
 	OutOfCluster   bool
+	noTeamsAPI bool
+	noDBAccess bool
 	version        string
 )
 
 func init() {
 	flag.StringVar(&KubeConfigFile, "kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
 	flag.BoolVar(&OutOfCluster, "outofcluster", false, "Whether the operator runs in- our outside of the Kubernetes cluster.")
+	flag.BoolVar(&noDBAccess, "nodatabaseaccess", false, "Disable all access to the database from the operator side.")
+	flag.BoolVar(&noTeamsAPI, "noteamsapi", false, "Disable all access to the teams API")
 	flag.Parse()
 
 	podNamespace = os.Getenv("MY_POD_NAMESPACE")
@@ -86,6 +90,12 @@ func main() {
 	}
 	if configMapData["namespace"] == "" { // Namespace in ConfigMap has priority over env var
 		configMapData["namespace"] = podNamespace
+	}
+	if noDBAccess {
+		configMapData["enable_db_access"] = "false"
+	}
+	if noTeamsAPI {
+		configMapData["enable_teams_api"] = "false"
 	}
 	cfg := config.NewFromMap(configMapData)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	KubeConfigFile string
-	podNamespace   string
-	configMapName  spec.NamespacedName
-	OutOfCluster   bool
-	noTeamsAPI bool
+	KubeConfigFile   string
+	podNamespace     string
+	configMapName    spec.NamespacedName
+	OutOfCluster     bool
+	noTeamsAPI       bool
 	noDatabaseAccess bool
-	version        string
+	version          string
 )
 
 func init() {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -227,18 +227,20 @@ func (c *Cluster) Create(stopCh <-chan struct{}) error {
 	}
 	c.logger.Infof("Pods are ready")
 
-	if !c.masterLess {
-		if err = c.initDbConn(); err != nil {
+	if !(c.masterLess || c.DatabaseAccessDisabled()) {
+		if err := c.initDbConn(); err != nil {
 			return fmt.Errorf("Can't init db connection: %s", err)
-		}
-
-		if err = c.createUsers(); err != nil {
-			return fmt.Errorf("Can't create users: %s", err)
 		} else {
-			c.logger.Infof("Users have been successfully created")
+			if err = c.createUsers(); err != nil {
+				return fmt.Errorf("Can't create users: %s", err)
+			} else {
+				c.logger.Infof("Users have been successfully created")
+			}
 		}
 	} else {
-		c.logger.Warnln("Cluster is masterless")
+		if c.masterLess {
+			c.logger.Warnln("Cluster is masterless")
+		}
 	}
 
 	c.ListResources()

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1,8 +1,8 @@
 package cluster
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 
 	"k8s.io/client-go/pkg/api/resource"
 	"k8s.io/client-go/pkg/api/v1"

--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -40,17 +40,17 @@ func (c *Cluster) DatabaseAccessDisabled() bool {
 }
 func (c *Cluster) initDbConn() (err error) {
 	if c.pgDb == nil {
-			conn, err := sql.Open("postgres", c.pgConnectionString())
-			if err != nil {
-				return err
-			}
-			err = conn.Ping()
-			if err != nil {
-				conn.Close()
-				return err
-			}
+		conn, err := sql.Open("postgres", c.pgConnectionString())
+		if err != nil {
+			return err
+		}
+		err = conn.Ping()
+		if err != nil {
+			conn.Close()
+			return err
+		}
 
-			c.pgDb = conn
+		c.pgDb = conn
 	}
 
 	return nil

--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -32,10 +32,14 @@ func (c *Cluster) pgConnectionString() string {
 		strings.Replace(password, "$", "\\$", -1))
 }
 
-func (c *Cluster) initDbConn() error {
-	//TODO: concurrent safe?
+func (c *Cluster) DatabaseAccessDisabled() bool {
+	if c.OpConfig.EnableDBAccess == false {
+		c.logger.Debugf("Database access is disabled")
+	}
+	return c.OpConfig.EnableDBAccess == false
+}
+func (c *Cluster) initDbConn() (err error) {
 	if c.pgDb == nil {
-		if c.pgDb == nil {
 			conn, err := sql.Open("postgres", c.pgConnectionString())
 			if err != nil {
 				return err
@@ -47,7 +51,6 @@ func (c *Cluster) initDbConn() error {
 			}
 
 			c.pgDb = conn
-		}
 	}
 
 	return nil

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -36,6 +36,9 @@ func (c *Cluster) SyncCluster(stopCh <-chan struct{}) {
 	if err := c.syncStatefulSet(); err != nil {
 		c.logger.Errorf("Can't sync StatefulSets: %s", err)
 	}
+	if c.DatabaseAccessDisabled() {
+		return
+	}
 	if err := c.initDbConn(); err != nil {
 		c.logger.Errorf("Can't init db connection: %s", err)
 	} else {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -50,7 +50,7 @@ func New(controllerConfig *Config, operatorConfig *config.Config) *Controller {
 		logger.Level = logrus.DebugLevel
 	}
 
-	controllerConfig.TeamsAPIClient = teams.NewTeamsAPI(operatorConfig.TeamsAPIUrl, logger)
+	controllerConfig.TeamsAPIClient = teams.NewTeamsAPI(operatorConfig.TeamsAPIUrl, logger, operatorConfig.EnableTeamsAPI)
 	return &Controller{
 		Config:   *controllerConfig,
 		opConfig: operatorConfig,

--- a/pkg/controller/exec.go
+++ b/pkg/controller/exec.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
+	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
-	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 
 	"github.com/zalando-incubator/postgres-operator/pkg/spec"
 )

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	WALES3Bucket       string `name:"wal_s3_bucket"`
 	KubeIAMRole        string `name:"kube_iam_role"`
 	DebugLogging       bool   `name:"debug_logging" default:"false"`
-	EnableDBAccess	   bool   `name:"enable_db_access" default:"true"`
+	EnableDBAccess	   bool   `name:"enable_database_access" default:"true"`
 	EnableTeamsAPI     bool   `name:"enable_teams_api" default:"true"`
 	DNSNameFormat      string `name:"dns_name_format" default:"%s.%s.%s"`
 	Workers            uint32 `name:"workers" default:"4"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	WALES3Bucket       string `name:"wal_s3_bucket"`
 	KubeIAMRole        string `name:"kube_iam_role"`
 	DebugLogging       bool   `name:"debug_logging" default:"false"`
-	EnableDBAccess	   bool   `name:"enable_database_access" default:"true"`
+	EnableDBAccess     bool   `name:"enable_database_access" default:"true"`
 	EnableTeamsAPI     bool   `name:"enable_teams_api" default:"true"`
 	DNSNameFormat      string `name:"dns_name_format" default:"%s.%s.%s"`
 	Workers            uint32 `name:"workers" default:"4"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -52,6 +52,8 @@ type Config struct {
 	WALES3Bucket       string `name:"wal_s3_bucket"`
 	KubeIAMRole        string `name:"kube_iam_role"`
 	DebugLogging       bool   `name:"debug_logging" default:"false"`
+	EnableDBAccess	   bool   `name:"enable_db_access" default:"true"`
+	EnableTeamsAPI     bool   `name:"enable_teams_api" default:"true"`
 	DNSNameFormat      string `name:"dns_name_format" default:"%s.%s.%s"`
 	Workers            uint32 `name:"workers" default:"4"`
 }

--- a/pkg/util/teams/teams.go
+++ b/pkg/util/teams/teams.go
@@ -42,13 +42,15 @@ type TeamsAPI struct {
 	httpClient         *http.Client
 	logger             *logrus.Entry
 	RefreshTokenAction func() (string, error)
+	enabled bool
 }
 
-func NewTeamsAPI(url string, log *logrus.Logger) *TeamsAPI {
+func NewTeamsAPI(url string, log *logrus.Logger, enabled bool) *TeamsAPI {
 	t := TeamsAPI{
 		url:        strings.TrimRight(url, "/"),
 		httpClient: &http.Client{},
 		logger:     log.WithField("pkg", "teamsapi"),
+		enabled: enabled,
 	}
 
 	return &t
@@ -56,6 +58,10 @@ func NewTeamsAPI(url string, log *logrus.Logger) *TeamsAPI {
 
 func (t *TeamsAPI) TeamInfo(teamId string) (*Team, error) {
 	// TODO: avoid getting a new token on every call to the Teams API.
+	if !t.enabled {
+		t.logger.Debug("Team API is disabled, returning empty list of members")
+		return &Team{}, nil
+	}
 	token, err := t.RefreshTokenAction()
 	if err != nil {
 		return nil, err

--- a/pkg/util/teams/teams.go
+++ b/pkg/util/teams/teams.go
@@ -42,7 +42,7 @@ type TeamsAPI struct {
 	httpClient         *http.Client
 	logger             *logrus.Entry
 	RefreshTokenAction func() (string, error)
-	enabled bool
+	enabled            bool
 }
 
 func NewTeamsAPI(url string, log *logrus.Logger, enabled bool) *TeamsAPI {
@@ -50,7 +50,7 @@ func NewTeamsAPI(url string, log *logrus.Logger, enabled bool) *TeamsAPI {
 		url:        strings.TrimRight(url, "/"),
 		httpClient: &http.Client{},
 		logger:     log.WithField("pkg", "teamsapi"),
-		enabled: enabled,
+		enabled:    enabled,
 	}
 
 	return &t


### PR DESCRIPTION
Command-line options --nodatabaseaccess and --noteamsapi disable all
teams api interaction and access to the Postgres database. This is
useful for debugging purposes when the operator runs out of cluster
(with --outofcluster flag).

The same effect can be achieved by setting enable_db_access and/or
enable_teams_api to false.