### PR TITLE
Return error instead of logging it

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -466,20 +466,20 @@ func (c *Cluster) Delete() error {
 	defer c.mu.Unlock()
 
 	if err := c.deleteEndpoint(); err != nil {
-		c.logger.Errorf("Can't delete Endpoint: %s", err)
+		return fmt.Errorf("Can't delete Endpoint: %s", err)
 	}
 
 	if err := c.deleteService(); err != nil {
-		c.logger.Errorf("Can't delete Service: %s", err)
+		return fmt.Errorf("Can't delete Service: %s", err)
 	}
 
 	if err := c.deleteStatefulSet(); err != nil {
-		c.logger.Errorf("Can't delete StatefulSet: %s", err)
+		return fmt.Errorf("Can't delete StatefulSet: %s", err)
 	}
 
 	for _, obj := range c.Secrets {
 		if err := c.deleteSecret(obj); err != nil {
-			c.logger.Errorf("Can't delete Secret: %s", err)
+			return fmt.Errorf("Can't delete Secret: %s", err)
 		}
 	}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -227,7 +227,7 @@ func (c *Cluster) Create(stopCh <-chan struct{}) error {
 	}
 	c.logger.Infof("Pods are ready")
 
-	if !(c.masterLess || c.DatabaseAccessDisabled()) {
+	if !(c.masterLess || c.databaseAccessDisabled()) {
 		if err := c.initDbConn(); err != nil {
 			return fmt.Errorf("Can't init db connection: %s", err)
 		} else {

--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -32,12 +32,14 @@ func (c *Cluster) pgConnectionString() string {
 		strings.Replace(password, "$", "\\$", -1))
 }
 
-func (c *Cluster) DatabaseAccessDisabled() bool {
+func (c *Cluster) databaseAccessDisabled() bool {
 	if c.OpConfig.EnableDBAccess == false {
 		c.logger.Debugf("Database access is disabled")
 	}
+
 	return c.OpConfig.EnableDBAccess == false
 }
+
 func (c *Cluster) initDbConn() (err error) {
 	if c.pgDb == nil {
 		conn, err := sql.Open("postgres", c.pgConnectionString())

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -6,7 +6,7 @@ import (
 	"github.com/zalando-incubator/postgres-operator/pkg/util"
 )
 
-func (c *Cluster) SyncCluster(stopCh <-chan struct{}) error {
+func (c *Cluster) Sync(stopCh <-chan struct{}) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -6,7 +6,7 @@ import (
 	"github.com/zalando-incubator/postgres-operator/pkg/util"
 )
 
-func (c *Cluster) SyncCluster(stopCh <-chan struct{}) {
+func (c *Cluster) SyncCluster(stopCh <-chan struct{}) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -19,35 +19,37 @@ func (c *Cluster) SyncCluster(stopCh <-chan struct{}) {
 
 	c.logger.Debugf("Syncing Secrets")
 	if err := c.syncSecrets(); err != nil {
-		c.logger.Infof("Can't sync Secrets: %s", err)
+		return fmt.Errorf("Can't sync Secrets: %s", err)
 	}
 
 	c.logger.Debugf("Syncing Endpoints")
 	if err := c.syncEndpoint(); err != nil {
-		c.logger.Errorf("Can't sync Endpoints: %s", err)
+		return fmt.Errorf("Can't sync Endpoints: %s", err)
 	}
 
 	c.logger.Debugf("Syncing Services")
 	if err := c.syncService(); err != nil {
-		c.logger.Errorf("Can't sync Services: %s", err)
+		return fmt.Errorf("Can't sync Services: %s", err)
 	}
 
 	c.logger.Debugf("Syncing StatefulSets")
 	if err := c.syncStatefulSet(); err != nil {
-		c.logger.Errorf("Can't sync StatefulSets: %s", err)
+		return fmt.Errorf("Can't sync StatefulSets: %s", err)
 	}
 
 	if c.databaseAccessDisabled() {
-		return
+		return nil
 	}
 	if err := c.initDbConn(); err != nil {
-		c.logger.Errorf("Can't init db connection: %s", err)
+		return fmt.Errorf("Can't init db connection: %s", err)
 	} else {
 		c.logger.Debugf("Syncing Roles")
 		if err := c.SyncRoles(); err != nil {
-			c.logger.Errorf("Can't sync Roles: %s", err)
+			return fmt.Errorf("Can't sync Roles: %s", err)
 		}
 	}
+
+	return nil
 }
 
 func (c *Cluster) syncSecrets() error {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -36,7 +36,8 @@ func (c *Cluster) SyncCluster(stopCh <-chan struct{}) {
 	if err := c.syncStatefulSet(); err != nil {
 		c.logger.Errorf("Can't sync StatefulSets: %s", err)
 	}
-	if c.DatabaseAccessDisabled() {
+
+	if c.databaseAccessDisabled() {
 		return
 	}
 	if err := c.initDbConn(); err != nil {

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -165,7 +165,10 @@ func (c *Controller) processEvent(obj interface{}) error {
 			c.clustersMu.Unlock()
 		}
 
-		cl.SyncCluster(stopCh)
+		if err := cl.SyncCluster(stopCh); err != nil {
+			logger.Errorf("Can't sync cluster '%s': %s", clusterName, err)
+			return nil
+		}
 
 		logger.Infof("Cluster '%s' has been synced", clusterName)
 	}

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -165,7 +165,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 			c.clustersMu.Unlock()
 		}
 
-		if err := cl.SyncCluster(stopCh); err != nil {
+		if err := cl.Sync(stopCh); err != nil {
 			logger.Errorf("Can't sync cluster '%s': %s", clusterName, err)
 			return nil
 		}


### PR DESCRIPTION
In order to make code more homogenous it would make sense to return error in methods like SyncCluster and Delete instead of just logging it