### PR TITLE
Fix error messages

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -104,7 +104,7 @@ func (c *Cluster) setStatus(status spec.PostgresStatus) {
 	c.Status = status
 	b, err := json.Marshal(status)
 	if err != nil {
-		c.logger.Fatalf("could not marshal status: %s", err)
+		c.logger.Fatalf("could not marshal status: %v", err)
 	}
 	request := []byte(fmt.Sprintf(`{"status": %s}`, string(b))) //TODO: Look into/wait for k8s go client methods
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -104,7 +104,7 @@ func (c *Cluster) setStatus(status spec.PostgresStatus) {
 	c.Status = status
 	b, err := json.Marshal(status)
 	if err != nil {
-		c.logger.Fatalf("Can't marshal status: %s", err)
+		c.logger.Fatalf("could not marshal status: %s", err)
 	}
 	request := []byte(fmt.Sprintf(`{"status": %s}`, string(b))) //TODO: Look into/wait for k8s go client methods
 
@@ -114,12 +114,12 @@ func (c *Cluster) setStatus(status spec.PostgresStatus) {
 		DoRaw()
 
 	if k8sutil.ResourceNotFound(err) {
-		c.logger.Warningf("Can't set status for the non-existing cluster")
+		c.logger.Warningf("could not set status for the non-existing cluster")
 		return
 	}
 
 	if err != nil {
-		c.logger.Warningf("Can't set status for cluster '%s': %s", c.ClusterName(), err)
+		c.logger.Warningf("could not set status for cluster '%s': %s", c.ClusterName(), err)
 	}
 }
 
@@ -127,15 +127,15 @@ func (c *Cluster) initUsers() error {
 	c.initSystemUsers()
 
 	if err := c.initInfrastructureRoles(); err != nil {
-		return fmt.Errorf("Can't init infrastructure roles: %s", err)
+		return fmt.Errorf("could not init infrastructure roles: %v", err)
 	}
 
 	if err := c.initRobotUsers(); err != nil {
-		return fmt.Errorf("Can't init robot users: %s", err)
+		return fmt.Errorf("could not init robot users: %v", err)
 	}
 
 	if err := c.initHumanUsers(); err != nil {
-		return fmt.Errorf("Can't init human users: %s", err)
+		return fmt.Errorf("could not init human users: %v", err)
 	}
 
 	c.logger.Debugf("Initialized users: %# v", util.Pretty(c.pgUsers))
@@ -166,15 +166,15 @@ func (c *Cluster) Create(stopCh <-chan struct{}) error {
 	//TODO: service will create endpoint implicitly
 	ep, err := c.createEndpoint()
 	if err != nil {
-		return fmt.Errorf("Can't create Endpoint: %s", err)
+		return fmt.Errorf("could not create endpoint: %v", err)
 	}
-	c.logger.Infof("Endpoint '%s' has been successfully created", util.NameFromMeta(ep.ObjectMeta))
+	c.logger.Infof("endpoint '%s' has been successfully created", util.NameFromMeta(ep.ObjectMeta))
 
 	service, err := c.createService()
 	if err != nil {
-		return fmt.Errorf("Can't create Service: %s", err)
+		return fmt.Errorf("could not create service: %v", err)
 	}
-	c.logger.Infof("Service '%s' has been successfully created", util.NameFromMeta(service.ObjectMeta))
+	c.logger.Infof("service '%s' has been successfully created", util.NameFromMeta(service.ObjectMeta))
 
 	if err = c.initUsers(); err != nil {
 		return err
@@ -182,15 +182,15 @@ func (c *Cluster) Create(stopCh <-chan struct{}) error {
 	c.logger.Infof("User secrets have been initialized")
 
 	if err = c.applySecrets(); err != nil {
-		return fmt.Errorf("Can't create Secrets: %s", err)
+		return fmt.Errorf("could not create secrets: %v", err)
 	}
-	c.logger.Infof("Secrets have been successfully created")
+	c.logger.Infof("secrets have been successfully created")
 
 	ss, err := c.createStatefulSet()
 	if err != nil {
-		return fmt.Errorf("Can't create StatefulSet: %s", err)
+		return fmt.Errorf("could not create statefulset: %v", err)
 	}
-	c.logger.Infof("StatefulSet '%s' has been successfully created", util.NameFromMeta(ss.ObjectMeta))
+	c.logger.Infof("statefulset '%s' has been successfully created", util.NameFromMeta(ss.ObjectMeta))
 
 	c.logger.Info("Waiting for cluster being ready")
 
@@ -198,14 +198,14 @@ func (c *Cluster) Create(stopCh <-chan struct{}) error {
 		c.logger.Errorf("Failed to create cluster: %s", err)
 		return err
 	}
-	c.logger.Infof("Pods are ready")
+	c.logger.Infof("pods are ready")
 
 	if !(c.masterLess || c.databaseAccessDisabled()) {
 		if err := c.initDbConn(); err != nil {
-			return fmt.Errorf("Can't init db connection: %s", err)
+			return fmt.Errorf("could not init db connection: %v", err)
 		}
 		if err = c.createUsers(); err != nil {
-			return fmt.Errorf("Can't create users: %s", err)
+			return fmt.Errorf("could not create users: %v", err)
 		}
 		c.logger.Infof("Users have been successfully created")
 	} else {
@@ -216,7 +216,7 @@ func (c *Cluster) Create(stopCh <-chan struct{}) error {
 
 	err = c.ListResources()
 	if err != nil {
-		c.logger.Errorf("Can't list resources: %s", err)
+		c.logger.Errorf("could not list resources: %s", err)
 	}
 
 	return nil
@@ -253,7 +253,7 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) (matc
 		reason = "new statefulset's container specification doesn't match the current one"
 	}
 	if len(c.Statefulset.Spec.Template.Spec.Containers) == 0 {
-		c.logger.Warnf("StatefulSet '%s' has no container", util.NameFromMeta(c.Statefulset.ObjectMeta))
+		c.logger.Warnf("statefulset '%s' has no container", util.NameFromMeta(c.Statefulset.ObjectMeta))
 		return
 	}
 	// In the comparisons below, the needsReplace and needsRollUpdate flags are never reset, since checks fall through
@@ -379,9 +379,9 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 		c.logServiceChanges(c.Service, newService, true, reason)
 		if err := c.updateService(newService); err != nil {
 			c.setStatus(spec.ClusterStatusUpdateFailed)
-			return fmt.Errorf("Can't update Service: %s", err)
+			return fmt.Errorf("could not update service: %v", err)
 		}
-		c.logger.Infof("Service '%s' has been updated", util.NameFromMeta(c.Service.ObjectMeta))
+		c.logger.Infof("service '%s' has been updated", util.NameFromMeta(c.Service.ObjectMeta))
 	}
 
 	if match, reason := c.sameVolumeWith(newSpec.Spec.Volume); !match {
@@ -391,7 +391,7 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 
 	newStatefulSet, err := c.genStatefulSet(newSpec.Spec)
 	if err != nil {
-		return fmt.Errorf("Can't generate StatefulSet: %s", err)
+		return fmt.Errorf("could not generate statefulset: %v", err)
 	}
 
 	sameSS, needsReplace, rollingUpdate, reason := c.compareStatefulSetWith(newStatefulSet)
@@ -402,16 +402,16 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 		if !needsReplace {
 			if err := c.updateStatefulSet(newStatefulSet); err != nil {
 				c.setStatus(spec.ClusterStatusUpdateFailed)
-				return fmt.Errorf("Can't upate StatefulSet: %s", err)
+				return fmt.Errorf("could not upate statefulset: %v", err)
 			}
 		} else {
 			if err := c.replaceStatefulSet(newStatefulSet); err != nil {
 				c.setStatus(spec.ClusterStatusUpdateFailed)
-				return fmt.Errorf("Can't replace StatefulSet: %s", err)
+				return fmt.Errorf("could not replace statefulset: %v", err)
 			}
 		}
 		//TODO: if there is a change in numberOfInstances, make sure Pods have been created/deleted
-		c.logger.Infof("StatefulSet '%s' has been updated", util.NameFromMeta(c.Statefulset.ObjectMeta))
+		c.logger.Infof("statefulset '%s' has been updated", util.NameFromMeta(c.Statefulset.ObjectMeta))
 	}
 
 	if c.Spec.PgVersion != newSpec.Spec.PgVersion { // PG versions comparison
@@ -425,7 +425,7 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 		// TODO: wait for actual streaming to the replica
 		if err := c.recreatePods(); err != nil {
 			c.setStatus(spec.ClusterStatusUpdateFailed)
-			return fmt.Errorf("Can't recreate Pods: %s", err)
+			return fmt.Errorf("could not recreate pods: %v", err)
 		}
 		c.logger.Infof("Rolling update has been finished")
 	}
@@ -439,20 +439,20 @@ func (c *Cluster) Delete() error {
 	defer c.mu.Unlock()
 
 	if err := c.deleteEndpoint(); err != nil {
-		return fmt.Errorf("Can't delete Endpoint: %s", err)
+		return fmt.Errorf("could not delete endpoint: %v", err)
 	}
 
 	if err := c.deleteService(); err != nil {
-		return fmt.Errorf("Can't delete Service: %s", err)
+		return fmt.Errorf("could not delete service: %v", err)
 	}
 
 	if err := c.deleteStatefulSet(); err != nil {
-		return fmt.Errorf("Can't delete StatefulSet: %s", err)
+		return fmt.Errorf("could not delete statefulset: %v", err)
 	}
 
 	for _, obj := range c.Secrets {
 		if err := c.deleteSecret(obj); err != nil {
-			return fmt.Errorf("Can't delete Secret: %s", err)
+			return fmt.Errorf("could not delete secret: %v", err)
 		}
 	}
 
@@ -481,12 +481,12 @@ func (c *Cluster) initSystemUsers() {
 func (c *Cluster) initRobotUsers() error {
 	for username, userFlags := range c.Spec.Users {
 		if !isValidUsername(username) {
-			return fmt.Errorf("Invalid username: '%s'", username)
+			return fmt.Errorf("invalid username: '%v'", username)
 		}
 
 		flags, err := normalizeUserFlags(userFlags)
 		if err != nil {
-			return fmt.Errorf("Invalid flags for user '%s': %s", username, err)
+			return fmt.Errorf("invalid flags for user '%v': %v", username, err)
 		}
 
 		c.pgUsers[username] = spec.PgUser{
@@ -502,7 +502,7 @@ func (c *Cluster) initRobotUsers() error {
 func (c *Cluster) initHumanUsers() error {
 	teamMembers, err := c.getTeamMembers()
 	if err != nil {
-		return fmt.Errorf("Can't get list of team members: %s", err)
+		return fmt.Errorf("could not get list of team members: %v", err)
 	}
 	for _, username := range teamMembers {
 		flags := []string{constants.RoleFlagLogin, constants.RoleFlagSuperuser}
@@ -517,11 +517,11 @@ func (c *Cluster) initInfrastructureRoles() error {
 	// add infrastucture roles from the operator's definition
 	for username, data := range c.InfrastructureRoles {
 		if !isValidUsername(username) {
-			return fmt.Errorf("Invalid username: '%s'", username)
+			return fmt.Errorf("invalid username: '%v'", username)
 		}
 		flags, err := normalizeUserFlags(data.Flags)
 		if err != nil {
-			return fmt.Errorf("Invalid flags for user '%s': %s", username, err)
+			return fmt.Errorf("invalid flags for user '%v': %v", username, err)
 		}
 		data.Flags = flags
 		c.pgUsers[username] = data

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -59,12 +59,12 @@ func (c *Cluster) resourceRequirements(resources spec.Resources) (*v1.ResourceRe
 
 	result.Requests, err = fillResourceList(specRequests, defaultRequests)
 	if err != nil {
-		return nil, fmt.Errorf("Can't fill resource requests: %s", err)
+		return nil, fmt.Errorf("could not fill resource requests: %v", err)
 	}
 
 	result.Limits, err = fillResourceList(specLimits, defaultLimits)
 	if err != nil {
-		return nil, fmt.Errorf("Can't fill resource limits: %s", err)
+		return nil, fmt.Errorf("could not fill resource limits: %v", err)
 	}
 
 	return &result, nil
@@ -77,23 +77,23 @@ func fillResourceList(spec spec.ResourceDescription, defaults spec.ResourceDescr
 	if spec.CPU != "" {
 		requests[v1.ResourceCPU], err = resource.ParseQuantity(spec.CPU)
 		if err != nil {
-			return nil, fmt.Errorf("Can't parse CPU quantity: %s", err)
+			return nil, fmt.Errorf("could not parse CPU quantity: %v", err)
 		}
 	} else {
 		requests[v1.ResourceCPU], err = resource.ParseQuantity(defaults.CPU)
 		if err != nil {
-			return nil, fmt.Errorf("Can't parse default CPU quantity: %s", err)
+			return nil, fmt.Errorf("could not parse default CPU quantity: %v", err)
 		}
 	}
 	if spec.Memory != "" {
 		requests[v1.ResourceMemory], err = resource.ParseQuantity(spec.Memory)
 		if err != nil {
-			return nil, fmt.Errorf("Can't parse memory quantity: %s", err)
+			return nil, fmt.Errorf("could not parse memory quantity: %v", err)
 		}
 	} else {
 		requests[v1.ResourceMemory], err = resource.ParseQuantity(defaults.Memory)
 		if err != nil {
-			return nil, fmt.Errorf("Can't parse default memory quantity: %s", err)
+			return nil, fmt.Errorf("could not parse default memory quantity: %v", err)
 		}
 	}
 
@@ -365,7 +365,7 @@ func persistentVolumeClaimTemplate(volumeSize, volumeStorageClass string) (*v1.P
 
 	quantity, err := resource.ParseQuantity(volumeSize)
 	if err != nil {
-		return nil, fmt.Errorf("Can't parse volume size: %s", err)
+		return nil, fmt.Errorf("could not parse volume size: %v", err)
 	}
 
 	volumeClaim := &v1.PersistentVolumeClaim{

--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -62,7 +62,7 @@ func (c *Cluster) readPgUsersFromDatabase(userNames []string) (users spec.PgUser
 	var rows *sql.Rows
 	users = make(spec.PgUserMap)
 	if rows, err = c.pgDb.Query(getUserSQL, pq.Array(userNames)); err != nil {
-		return nil, fmt.Errorf("Error when querying users: %s", err)
+		return nil, fmt.Errorf("error when querying users: %v", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -74,7 +74,7 @@ func (c *Cluster) readPgUsersFromDatabase(userNames []string) (users spec.PgUser
 		err := rows.Scan(&rolname, &rolpassword, &rolsuper, &rolinherit,
 			&rolcreaterole, &rolcreatedb, &rolcanlogin, pq.Array(&memberof))
 		if err != nil {
-			return nil, fmt.Errorf("Error when processing user rows: %s", err)
+			return nil, fmt.Errorf("error when processing user rows: %v", err)
 		}
 		flags := makeUserFlags(rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin)
 		// XXX: the code assumes the password we get from pg_authid is always MD5

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -18,7 +18,7 @@ func (c *Cluster) listPods() ([]v1.Pod, error) {
 
 	pods, err := c.KubeClient.Pods(ns).List(listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("Can't get list of Pods: %s", err)
+		return nil, fmt.Errorf("could not get list of pods: %v", err)
 	}
 
 	return pods.Items, nil
@@ -32,13 +32,13 @@ func (c *Cluster) listPersistentVolumeClaims() ([]v1.PersistentVolumeClaim, erro
 
 	pvcs, err := c.KubeClient.PersistentVolumeClaims(ns).List(listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("Can't get list of PersistentVolumeClaims: %s", err)
+		return nil, fmt.Errorf("could not get list of PersistentVolumeClaims: %v", err)
 	}
 	return pvcs.Items, nil
 }
 
 func (c *Cluster) deletePods() error {
-	c.logger.Debugln("Deleting Pods")
+	c.logger.Debugln("Deleting pods")
 	pods, err := c.listPods()
 	if err != nil {
 		return err
@@ -47,17 +47,17 @@ func (c *Cluster) deletePods() error {
 	for _, obj := range pods {
 		podName := util.NameFromMeta(obj.ObjectMeta)
 
-		c.logger.Debugf("Deleting Pod '%s'", podName)
+		c.logger.Debugf("Deleting pod '%s'", podName)
 		if err := c.deletePod(podName); err != nil {
-			c.logger.Errorf("Can't delete Pod '%s': %s", podName, err)
+			c.logger.Errorf("could not delete pod '%s': %s", podName, err)
 		} else {
-			c.logger.Infof("Pod '%s' has been deleted", podName)
+			c.logger.Infof("pod '%s' has been deleted", podName)
 		}
 	}
 	if len(pods) > 0 {
-		c.logger.Debugln("Pods have been deleted")
+		c.logger.Debugln("pods have been deleted")
 	} else {
-		c.logger.Debugln("No Pods to delete")
+		c.logger.Debugln("No pods to delete")
 	}
 
 	return nil
@@ -73,7 +73,7 @@ func (c *Cluster) deletePersistenVolumeClaims() error {
 	for _, pvc := range pvcs {
 		c.logger.Debugf("Deleting PVC '%s'", util.NameFromMeta(pvc.ObjectMeta))
 		if err := c.KubeClient.PersistentVolumeClaims(ns).Delete(pvc.Name, c.deleteOptions); err != nil {
-			c.logger.Warningf("Can't delete PersistentVolumeClaim: %s", err)
+			c.logger.Warningf("could not delete PersistentVolumeClaim: %s", err)
 		}
 	}
 	if len(pvcs) > 0 {
@@ -105,7 +105,7 @@ func (c *Cluster) unregisterPodSubscriber(podName spec.NamespacedName) {
 	defer c.podSubscribersMu.Unlock()
 
 	if _, ok := c.podSubscribers[podName]; !ok {
-		panic("Subscriber for Pod '" + podName.String() + "' is not found")
+		panic("Subscriber for pod '" + podName.String() + "' is not found")
 	}
 
 	close(c.podSubscribers[podName])
@@ -118,7 +118,7 @@ func (c *Cluster) registerPodSubscriber(podName spec.NamespacedName) chan spec.P
 
 	ch := make(chan spec.PodEvent)
 	if _, ok := c.podSubscribers[podName]; ok {
-		panic("Pod '" + podName.String() + "' is already subscribed")
+		panic("pod '" + podName.String() + "' is already subscribed")
 	}
 	c.podSubscribers[podName] = ch
 
@@ -132,7 +132,7 @@ func (c *Cluster) recreatePod(pod v1.Pod) error {
 	defer c.unregisterPodSubscriber(podName)
 
 	if err := c.KubeClient.Pods(pod.Namespace).Delete(pod.Name, c.deleteOptions); err != nil {
-		return fmt.Errorf("Can't delete Pod: %s", err)
+		return fmt.Errorf("could not delete pod: %v", err)
 	}
 
 	if err := c.waitForPodDeletion(ch); err != nil {
@@ -141,7 +141,7 @@ func (c *Cluster) recreatePod(pod v1.Pod) error {
 	if err := c.waitForPodLabel(ch); err != nil {
 		return err
 	}
-	c.logger.Infof("Pod '%s' is ready", podName)
+	c.logger.Infof("pod '%s' is ready", podName)
 
 	return nil
 }
@@ -173,9 +173,9 @@ func (c *Cluster) recreatePods() error {
 
 	pods, err := c.KubeClient.Pods(namespace).List(listOptions)
 	if err != nil {
-		return fmt.Errorf("Can't get the list of Pods: %s", err)
+		return fmt.Errorf("could not get the list of pods: %v", err)
 	}
-	c.logger.Infof("There are %d Pods in the cluster to recreate", len(pods.Items))
+	c.logger.Infof("There are %d pods in the cluster to recreate", len(pods.Items))
 
 	var masterPod v1.Pod
 	for _, pod := range pods.Items {
@@ -187,19 +187,19 @@ func (c *Cluster) recreatePods() error {
 		}
 
 		if err := c.recreatePod(pod); err != nil {
-			return fmt.Errorf("Can't recreate replica Pod '%s': %s", util.NameFromMeta(pod.ObjectMeta), err)
+			return fmt.Errorf("could not recreate replica pod '%s': %v", util.NameFromMeta(pod.ObjectMeta), err)
 		}
 	}
 	if masterPod.Name == "" {
-		c.logger.Warningln("No master Pod in the cluster")
+		c.logger.Warningln("No master pod in the cluster")
 	}
 
 	//TODO: do manual failover
 	//TODO: specify master, leave new master empty
-	c.logger.Infof("Recreating master Pod '%s'", util.NameFromMeta(masterPod.ObjectMeta))
+	c.logger.Infof("Recreating master pod '%s'", util.NameFromMeta(masterPod.ObjectMeta))
 
 	if err := c.recreatePod(masterPod); err != nil {
-		return fmt.Errorf("Can't recreate master Pod '%s': %s", util.NameFromMeta(masterPod.ObjectMeta), err)
+		return fmt.Errorf("could not recreate master pod '%s': %v", util.NameFromMeta(masterPod.ObjectMeta), err)
 	}
 
 	return nil

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -73,7 +73,7 @@ func (c *Cluster) deletePersistenVolumeClaims() error {
 	for _, pvc := range pvcs {
 		c.logger.Debugf("Deleting PVC '%s'", util.NameFromMeta(pvc.ObjectMeta))
 		if err := c.KubeClient.PersistentVolumeClaims(ns).Delete(pvc.Name, c.deleteOptions); err != nil {
-			c.logger.Warningf("could not delete PersistentVolumeClaim: %s", err)
+			c.logger.Warningf("could not delete PersistentVolumeClaim: %v", err)
 		}
 	}
 	if len(pvcs) > 0 {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -78,12 +78,12 @@ func (c *Cluster) syncSecrets() error {
 func (c *Cluster) syncService() error {
 	cSpec := c.Spec
 	if c.Service == nil {
-		c.logger.Infof("Can't find the cluster's Service")
+		c.logger.Infof("could not find the cluster's service")
 		svc, err := c.createService()
 		if err != nil {
-			return fmt.Errorf("Can't create missing Service: %s", err)
+			return fmt.Errorf("could not create missing service: %v", err)
 		}
-		c.logger.Infof("Created missing Service '%s'", util.NameFromMeta(svc.ObjectMeta))
+		c.logger.Infof("Created missing service '%s'", util.NameFromMeta(svc.ObjectMeta))
 
 		return nil
 	}
@@ -96,21 +96,21 @@ func (c *Cluster) syncService() error {
 	c.logServiceChanges(c.Service, desiredSvc, false, reason)
 
 	if err := c.updateService(desiredSvc); err != nil {
-		return fmt.Errorf("Can't update Service to match desired state: %s", err)
+		return fmt.Errorf("could not update service to match desired state: %v", err)
 	}
-	c.logger.Infof("Service '%s' is in the desired state now", util.NameFromMeta(desiredSvc.ObjectMeta))
+	c.logger.Infof("service '%s' is in the desired state now", util.NameFromMeta(desiredSvc.ObjectMeta))
 
 	return nil
 }
 
 func (c *Cluster) syncEndpoint() error {
 	if c.Endpoint == nil {
-		c.logger.Infof("Can't find the cluster's Endpoint")
+		c.logger.Infof("could not find the cluster's endpoint")
 		ep, err := c.createEndpoint()
 		if err != nil {
-			return fmt.Errorf("Can't create missing Endpoint: %s", err)
+			return fmt.Errorf("could not create missing endpoint: %v", err)
 		}
-		c.logger.Infof("Created missing Endpoint '%s'", util.NameFromMeta(ep.ObjectMeta))
+		c.logger.Infof("Created missing endpoint '%s'", util.NameFromMeta(ep.ObjectMeta))
 		return nil
 	}
 
@@ -121,10 +121,10 @@ func (c *Cluster) syncStatefulSet() error {
 	cSpec := c.Spec
 	var rollUpdate, needsReplace bool
 	if c.Statefulset == nil {
-		c.logger.Infof("Can't find the cluster's StatefulSet")
+		c.logger.Infof("could not find the cluster's statefulset")
 		pods, err := c.listPods()
 		if err != nil {
-			return fmt.Errorf("Can't list pods of the StatefulSet: %s", err)
+			return fmt.Errorf("could not list pods of the statefulset: %v", err)
 		}
 
 		if len(pods) > 0 {
@@ -133,13 +133,13 @@ func (c *Cluster) syncStatefulSet() error {
 		}
 		ss, err := c.createStatefulSet()
 		if err != nil {
-			return fmt.Errorf("Can't create missing StatefulSet: %s", err)
+			return fmt.Errorf("could not create missing statefulset: %v", err)
 		}
 		err = c.waitStatefulsetPodsReady()
 		if err != nil {
-			return fmt.Errorf("Cluster is not ready: %s", err)
+			return fmt.Errorf("cluster is not ready: %v", err)
 		}
-		c.logger.Infof("Created missing StatefulSet '%s'", util.NameFromMeta(ss.ObjectMeta))
+		c.logger.Infof("Created missing statefulset '%s'", util.NameFromMeta(ss.ObjectMeta))
 		if !rollUpdate {
 			return nil
 		}
@@ -152,7 +152,7 @@ func (c *Cluster) syncStatefulSet() error {
 
 		desiredSS, err := c.genStatefulSet(cSpec)
 		if err != nil {
-			return fmt.Errorf("Can't generate StatefulSet: %s", err)
+			return fmt.Errorf("could not generate statefulset: %v", err)
 		}
 
 		match, needsReplace, rollUpdate, reason = c.compareStatefulSetWith(desiredSS)
@@ -163,11 +163,11 @@ func (c *Cluster) syncStatefulSet() error {
 
 		if !needsReplace {
 			if err := c.updateStatefulSet(desiredSS); err != nil {
-				return fmt.Errorf("Can't update StatefulSet: %s", err)
+				return fmt.Errorf("could not update statefulset: %v", err)
 			}
 		} else {
 			if err := c.replaceStatefulSet(desiredSS); err != nil {
-				return fmt.Errorf("Can't replace StatefulSet: %s", err)
+				return fmt.Errorf("could not replace statefulset: %v", err)
 			}
 		}
 
@@ -178,9 +178,9 @@ func (c *Cluster) syncStatefulSet() error {
 	}
 	c.logger.Debugln("Performing rolling update")
 	if err := c.recreatePods(); err != nil {
-		return fmt.Errorf("Can't recreate Pods: %s", err)
+		return fmt.Errorf("could not recreate pods: %v", err)
 	}
-	c.logger.Infof("Pods have been recreated")
+	c.logger.Infof("pods have been recreated")
 
 	return nil
 }
@@ -196,11 +196,11 @@ func (c *Cluster) SyncRoles() error {
 	}
 	dbUsers, err := c.readPgUsersFromDatabase(userNames)
 	if err != nil {
-		return fmt.Errorf("Error getting users from the database: %s", err)
+		return fmt.Errorf("error getting users from the database: %v", err)
 	}
 	pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(dbUsers, c.pgUsers)
 	if err := c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
-		return fmt.Errorf("Error executing sync statements: %s", err)
+		return fmt.Errorf("error executing sync statements: %v", err)
 	}
 	return nil
 }

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -26,7 +26,7 @@ func normalizeUserFlags(userFlags []string) (flags []string, err error) {
 
 	for _, flag := range userFlags {
 		if !alphaNumericRegexp.MatchString(flag) {
-			err = fmt.Errorf("User flag '%s' is not alphanumeric", flag)
+			err = fmt.Errorf("user flag '%v' is not alphanumeric", flag)
 			return
 		}
 		flag = strings.ToUpper(flag)
@@ -35,7 +35,7 @@ func normalizeUserFlags(userFlags []string) (flags []string, err error) {
 		}
 	}
 	if uniqueFlags[constants.RoleFlagLogin] && uniqueFlags[constants.RoleFlagNoLogin] {
-		return nil, fmt.Errorf("Conflicting or redundant flags: LOGIN and NOLOGIN")
+		return nil, fmt.Errorf("conflicting or redundant flags: LOGIN and NOLOGIN")
 	}
 
 	flags = []string{}
@@ -65,11 +65,11 @@ func specPatch(spec interface{}) ([]byte, error) {
 
 func (c *Cluster) logStatefulSetChanges(old, new *v1beta1.StatefulSet, isUpdate bool, reason string) {
 	if isUpdate {
-		c.logger.Infof("StatefulSet '%s' has been changed",
+		c.logger.Infof("statefulset '%s' has been changed",
 			util.NameFromMeta(old.ObjectMeta),
 		)
 	} else {
-		c.logger.Infof("StatefulSet '%s' is not in the desired state and needs to be updated",
+		c.logger.Infof("statefulset '%s' is not in the desired state and needs to be updated",
 			util.NameFromMeta(old.ObjectMeta),
 		)
 	}
@@ -82,11 +82,11 @@ func (c *Cluster) logStatefulSetChanges(old, new *v1beta1.StatefulSet, isUpdate 
 
 func (c *Cluster) logServiceChanges(old, new *v1.Service, isUpdate bool, reason string) {
 	if isUpdate {
-		c.logger.Infof("Service '%s' has been changed",
+		c.logger.Infof("service '%s' has been changed",
 			util.NameFromMeta(old.ObjectMeta),
 		)
 	} else {
-		c.logger.Infof("Service '%s  is not in the desired state and needs to be updated",
+		c.logger.Infof("service '%s  is not in the desired state and needs to be updated",
 			util.NameFromMeta(old.ObjectMeta),
 		)
 	}
@@ -107,11 +107,11 @@ func (c *Cluster) logVolumeChanges(old, new spec.Volume, reason string) {
 
 func (c *Cluster) getTeamMembers() ([]string, error) {
 	if c.Spec.TeamID == "" {
-		return nil, fmt.Errorf("No teamId specified")
+		return nil, fmt.Errorf("no teamId specified")
 	}
 	teamInfo, err := c.TeamsAPIClient.TeamInfo(c.Spec.TeamID)
 	if err != nil {
-		return nil, fmt.Errorf("Can't get team info: %s", err)
+		return nil, fmt.Errorf("could not get team info: %v", err)
 	}
 	c.logger.Debugf("Got from the Team API: %+v", *teamInfo)
 
@@ -130,7 +130,7 @@ func (c *Cluster) waitForPodLabel(podEvents chan spec.PodEvent) error {
 				return nil
 			}
 		case <-time.After(c.OpConfig.PodLabelWaitTimeout):
-			return fmt.Errorf("Pod label wait timeout")
+			return fmt.Errorf("pod label wait timeout")
 		}
 	}
 }
@@ -143,7 +143,7 @@ func (c *Cluster) waitForPodDeletion(podEvents chan spec.PodEvent) error {
 				return nil
 			}
 		case <-time.After(c.OpConfig.PodDeletionWaitTimeout):
-			return fmt.Errorf("Pod deletion wait timeout")
+			return fmt.Errorf("pod deletion wait timeout")
 		}
 	}
 }
@@ -160,7 +160,7 @@ func (c *Cluster) waitStatefulsetReady() error {
 			}
 
 			if len(ss.Items) != 1 {
-				return false, fmt.Errorf("StatefulSet is not found")
+				return false, fmt.Errorf("statefulset is not found")
 			}
 
 			return *ss.Items[0].Spec.Replicas == ss.Items[0].Status.Replicas, nil
@@ -201,7 +201,7 @@ func (c *Cluster) waitPodLabelsReady() error {
 				return false, err
 			}
 			if len(masterPods.Items) > 1 {
-				return false, fmt.Errorf("Too many masters")
+				return false, fmt.Errorf("too many masters")
 			}
 			if len(replicaPods.Items) == podsNumber {
 				c.masterLess = true
@@ -219,12 +219,12 @@ func (c *Cluster) waitPodLabelsReady() error {
 func (c *Cluster) waitStatefulsetPodsReady() error {
 	// TODO: wait for the first Pod only
 	if err := c.waitStatefulsetReady(); err != nil {
-		return fmt.Errorf("Statuful set error: %s", err)
+		return fmt.Errorf("statuful set error: %v", err)
 	}
 
 	// TODO: wait only for master
 	if err := c.waitPodLabelsReady(); err != nil {
-		return fmt.Errorf("Pod labels error: %s", err)
+		return fmt.Errorf("pod labels error: %v", err)
 	}
 
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -75,12 +75,12 @@ func (c *Controller) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 
 func (c *Controller) initController() {
 	if err := c.createTPR(); err != nil {
-		c.logger.Fatalf("could not register ThirdPartyResource: %s", err)
+		c.logger.Fatalf("could not register ThirdPartyResource: %v", err)
 	}
 
 	c.TeamsAPIClient.RefreshTokenAction = c.getOAuthToken
 	if infraRoles, err := c.getInfrastructureRoles(); err != nil {
-		c.logger.Warningf("could not get infrastructure roles: %s", err)
+		c.logger.Warningf("could not get infrastructure roles: %v", err)
 	} else {
 		c.InfrastructureRoles = infraRoles
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -26,8 +26,8 @@ type Config struct {
 
 type Controller struct {
 	Config
-	opConfig    *config.Config
-	logger      *logrus.Entry
+	opConfig *config.Config
+	logger   *logrus.Entry
 
 	clustersMu sync.RWMutex
 	clusters   map[spec.NamespacedName]*cluster.Cluster
@@ -75,12 +75,12 @@ func (c *Controller) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 
 func (c *Controller) initController() {
 	if err := c.createTPR(); err != nil {
-		c.logger.Fatalf("Can't register ThirdPartyResource: %s", err)
+		c.logger.Fatalf("could not register ThirdPartyResource: %s", err)
 	}
 
 	c.TeamsAPIClient.RefreshTokenAction = c.getOAuthToken
 	if infraRoles, err := c.getInfrastructureRoles(); err != nil {
-		c.logger.Warningf("Can't get infrastructure roles: %s", err)
+		c.logger.Warningf("could not get infrastructure roles: %s", err)
 	} else {
 		c.InfrastructureRoles = infraRoles
 	}
@@ -125,7 +125,7 @@ func (c *Controller) initController() {
 		c.clusterEventQueues[i] = cache.NewFIFO(func(obj interface{}) (string, error) {
 			e, ok := obj.(spec.ClusterEvent)
 			if !ok {
-				return "", fmt.Errorf("Can't cast to ClusterEvent")
+				return "", fmt.Errorf("could not cast to ClusterEvent")
 			}
 
 			return fmt.Sprintf("%s-%s", e.EventType, e.UID), nil

--- a/pkg/controller/exec.go
+++ b/pkg/controller/exec.go
@@ -19,11 +19,11 @@ func (c *Controller) ExecCommand(podName spec.NamespacedName, command []string) 
 
 	pod, err := c.KubeClient.Pods(podName.Namespace).Get(podName.Name)
 	if err != nil {
-		return "", fmt.Errorf("Can't get Pod info: %s", err)
+		return "", fmt.Errorf("could not get pod info: %v", err)
 	}
 
 	if len(pod.Spec.Containers) != 1 {
-		return "", fmt.Errorf("Can't determine which container to use")
+		return "", fmt.Errorf("could not determine which container to use")
 	}
 
 	req := c.RestClient.Post().
@@ -40,7 +40,7 @@ func (c *Controller) ExecCommand(podName spec.NamespacedName, command []string) 
 
 	exec, err := remotecommand.NewExecutor(c.RestConfig, "POST", req.URL())
 	if err != nil {
-		return "", fmt.Errorf("Failed to init executor: %s", err)
+		return "", fmt.Errorf("failed to init executor: %v", err)
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
@@ -50,11 +50,11 @@ func (c *Controller) ExecCommand(podName spec.NamespacedName, command []string) 
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("Can't execute: %s", err)
+		return "", fmt.Errorf("could not execute: %v", err)
 	}
 
 	if execErr.Len() > 0 {
-		return "", fmt.Errorf("Stderr: %s", execErr.String())
+		return "", fmt.Errorf("stderr: %v", execErr.String())
 	}
 
 	return execOut.String(), nil

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -110,7 +110,7 @@ func (c *Controller) podDelete(obj interface{}) {
 }
 
 func (c *Controller) podEventsDispatcher(stopCh <-chan struct{}) {
-	c.logger.Infof("Watching all Pod events")
+	c.logger.Infof("Watching all pod events")
 	for {
 		select {
 		case event := <-c.podCh:
@@ -119,7 +119,7 @@ func (c *Controller) podEventsDispatcher(stopCh <-chan struct{}) {
 			c.clustersMu.RUnlock()
 
 			if ok {
-				c.logger.Debugf("Sending %s event of Pod '%s' to the '%s' cluster channel", event.EventType, event.PodName, event.ClusterName)
+				c.logger.Debugf("Sending %s event of pod '%s' to the '%s' cluster channel", event.EventType, event.PodName, event.ClusterName)
 				go subscriber.ReceivePodEvent(event)
 			}
 		case <-stopCh:

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -29,19 +29,19 @@ func (c *Controller) clusterListFunc(options api.ListOptions) (runtime.Object, e
 	object, err := req.Do().Get()
 
 	if err != nil {
-		return nil, fmt.Errorf("Can't get list of postgresql objects: %s", err)
+		return nil, fmt.Errorf("could not get list of postgresql objects: %v", err)
 	}
 
 	objList, err := meta.ExtractList(object)
 	if err != nil {
-		return nil, fmt.Errorf("Can't extract list of postgresql objects: %s", err)
+		return nil, fmt.Errorf("could not extract list of postgresql objects: %v", err)
 	}
 
 	var activeClustersCnt, failedClustersCnt int
 	for _, obj := range objList {
 		pg, ok := obj.(*spec.Postgresql)
 		if !ok {
-			return nil, fmt.Errorf("Can't cast object to postgresql")
+			return nil, fmt.Errorf("could not cast object to postgresql")
 		}
 
 		if pg.Error != nil {
@@ -82,7 +82,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 
 	event, ok := obj.(spec.ClusterEvent)
 	if !ok {
-		return fmt.Errorf("Can't cast to ClusterEvent")
+		return fmt.Errorf("could not cast to ClusterEvent")
 	}
 	logger := c.logger.WithField("worker", event.WorkerID)
 
@@ -115,7 +115,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 		c.clustersMu.Unlock()
 
 		if err := cl.Create(stopCh); err != nil {
-			logger.Errorf("Can't create cluster: %s", err)
+			logger.Errorf("could not create cluster: %s", err)
 			return nil
 		}
 
@@ -128,7 +128,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 			return nil
 		}
 		if err := cl.Update(event.NewSpec); err != nil {
-			logger.Errorf("Can't update cluster: %s", err)
+			logger.Errorf("could not update cluster: %s", err)
 			return nil
 		}
 		logger.Infof("Cluster '%s' has been updated", clusterName)
@@ -140,7 +140,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 		}
 
 		if err := cl.Delete(); err != nil {
-			logger.Errorf("Can't delete cluster '%s': %s", clusterName, err)
+			logger.Errorf("could not delete cluster '%s': %s", clusterName, err)
 			return nil
 		}
 		close(c.stopChs[clusterName])
@@ -166,7 +166,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 		}
 
 		if err := cl.Sync(stopCh); err != nil {
-			logger.Errorf("Can't sync cluster '%s': %s", clusterName, err)
+			logger.Errorf("could not sync cluster '%s': %s", clusterName, err)
 			return nil
 		}
 
@@ -226,7 +226,7 @@ func (c *Controller) queueClusterEvent(old, new *spec.Postgresql, eventType spec
 func (c *Controller) postgresqlAdd(obj interface{}) {
 	pg, ok := obj.(*spec.Postgresql)
 	if !ok {
-		c.logger.Errorf("Can't cast to postgresql spec")
+		c.logger.Errorf("could not cast to postgresql spec")
 		return
 	}
 
@@ -237,11 +237,11 @@ func (c *Controller) postgresqlAdd(obj interface{}) {
 func (c *Controller) postgresqlUpdate(prev, cur interface{}) {
 	pgOld, ok := prev.(*spec.Postgresql)
 	if !ok {
-		c.logger.Errorf("Can't cast to postgresql spec")
+		c.logger.Errorf("could not cast to postgresql spec")
 	}
 	pgNew, ok := cur.(*spec.Postgresql)
 	if !ok {
-		c.logger.Errorf("Can't cast to postgresql spec")
+		c.logger.Errorf("could not cast to postgresql spec")
 	}
 	if pgOld.Metadata.ResourceVersion == pgNew.Metadata.ResourceVersion {
 		return
@@ -256,7 +256,7 @@ func (c *Controller) postgresqlUpdate(prev, cur interface{}) {
 func (c *Controller) postgresqlDelete(obj interface{}) {
 	pg, ok := obj.(*spec.Postgresql)
 	if !ok {
-		c.logger.Errorf("Can't cast to postgresql spec")
+		c.logger.Errorf("could not cast to postgresql spec")
 		return
 	}
 

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -205,7 +205,7 @@ func (c *Controller) queueClusterEvent(old, new *spec.Postgresql, eventType spec
 	}
 
 	if clusterError != nil && eventType != spec.EventDelete {
-		c.logger.Debugf("Skipping %s event for invalid cluster %s (reason: %s)", eventType, clusterName, clusterError)
+		c.logger.Debugf("Skipping %s event for invalid cluster %s (reason: %v)", eventType, clusterName, clusterError)
 		return
 	}
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -37,12 +37,12 @@ func (c *Controller) getOAuthToken() (string, error) {
 
 	if err != nil {
 		c.logger.Debugf("Oauth token secret name: %s", c.opConfig.OAuthTokenSecretName)
-		return "", fmt.Errorf("Can't get credentials Secret: %s", err)
+		return "", fmt.Errorf("could not get credentials secret: %v", err)
 	}
 	data := credentialsSecret.Data
 
 	if string(data["read-only-token-type"]) != "Bearer" {
-		return "", fmt.Errorf("Wrong token type: %s", data["read-only-token-type"])
+		return "", fmt.Errorf("wrong token type: %v", data["read-only-token-type"])
 	}
 
 	return string(data["read-only-token-secret"]), nil
@@ -93,7 +93,7 @@ func (c *Controller) getInfrastructureRoles() (result map[string]spec.PgUser, er
 		Get(c.opConfig.InfrastructureRolesSecretName.Name)
 	if err != nil {
 		c.logger.Debugf("Infrastructure roles secret name: %s", c.opConfig.InfrastructureRolesSecretName)
-		return nil, fmt.Errorf("Can't get infrastructure roles Secret: %s", err)
+		return nil, fmt.Errorf("could not get infrastructure roles secret: %v", err)
 	}
 
 	data := infraRolesSecret.Data

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -102,7 +102,7 @@ func parseTime(s string) (t time.Time, wd time.Weekday, wdProvided bool, err err
 	parts := strings.Split(s, ":")
 	if len(parts) == 3 {
 		if len(parts[0]) != 3 || !alphaRegexp.MatchString(parts[0]) {
-			err = fmt.Errorf("Weekday must be 3 characters length")
+			err = fmt.Errorf("weekday must be 3 characters length")
 			return
 		}
 		timeLayout = "Mon:15:04"
@@ -148,7 +148,7 @@ func (m *MaintenanceWindow) UnmarshalJSON(data []byte) error {
 
 	parts := strings.Split(string(data[1:len(data)-1]), "-")
 	if len(parts) != 2 {
-		return fmt.Errorf("Incorrect maintenance window format")
+		return fmt.Errorf("incorrect maintenance window format")
 	}
 
 	got.StartTime, got.StartWeekday, weekdayProvidedFrom, err = parseTime(parts[0])
@@ -194,10 +194,10 @@ func (pl *PostgresqlList) GetListMeta() unversioned.List {
 func clusterName(clusterName string, teamName string) (string, error) {
 	teamNameLen := len(teamName)
 	if len(clusterName) < teamNameLen+2 {
-		return "", fmt.Errorf("Name is too short")
+		return "", fmt.Errorf("name is too short")
 	}
 	if strings.ToLower(clusterName[:teamNameLen+1]) != strings.ToLower(teamName)+"-" {
-		return "", fmt.Errorf("Name must match {TEAM}-{NAME} format")
+		return "", fmt.Errorf("name must match {TEAM}-{NAME} format")
 	}
 
 	return clusterName[teamNameLen+1:], nil

--- a/pkg/util/retryutil/retry_util.go
+++ b/pkg/util/retryutil/retry_util.go
@@ -10,7 +10,7 @@ type ConditionFunc func() (bool, error)
 func Retry(interval time.Duration, timeout time.Duration, f ConditionFunc) error {
 	//TODO: make the retry exponential
 	if timeout < interval {
-		return fmt.Errorf("timout(%s) should be greater than interval(%s)", timeout, interval)
+		return fmt.Errorf("timout(%s) should be greater than interval(%v)", timeout, interval)
 	}
 	maxRetries := int(timeout / interval)
 	tick := time.NewTicker(interval)
@@ -29,5 +29,5 @@ func Retry(interval time.Duration, timeout time.Duration, f ConditionFunc) error
 		}
 		<-tick.C
 	}
-	return fmt.Errorf("Still failing after %d retries", maxRetries)
+	return fmt.Errorf("still failing after %d retries", maxRetries)
 }

--- a/pkg/util/teams/teams.go
+++ b/pkg/util/teams/teams.go
@@ -88,10 +88,10 @@ func (t *API) TeamInfo(teamID string) (*Team, error) {
 		}
 
 		if errMessage, ok := raw["error"]; ok {
-			return nil, fmt.Errorf("Team API query failed with status code %d and message: '%s'", resp.StatusCode, string(errMessage))
+			return nil, fmt.Errorf("team API query failed with status code %d and message: '%v'", resp.StatusCode, string(errMessage))
 		}
 
-		return nil, fmt.Errorf("Team API query failed with status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("team API query failed with status code %d", resp.StatusCode)
 	}
 	teamInfo := &Team{}
 	d := json.NewDecoder(resp.Body)

--- a/pkg/util/users/users.go
+++ b/pkg/util/users/users.go
@@ -60,14 +60,14 @@ func (s DefaultUserSyncStrategy) ExecuteSyncRequests(reqs []spec.PgSyncUserReque
 		switch r.Kind {
 		case spec.PGSyncUserAdd:
 			if err := s.createPgUser(r.User, db); err != nil {
-				return fmt.Errorf("Can't create user '%s': %s", r.User.Name, err)
+				return fmt.Errorf("could not create user '%s': %v", r.User.Name, err)
 			}
 		case spec.PGsyncUserAlter:
 			if err := s.alterPgUser(r.User, db); err != nil {
-				return fmt.Errorf("Can't alter user '%s': %s", r.User.Name, err)
+				return fmt.Errorf("could not alter user '%s': %v", r.User.Name, err)
 			}
 		default:
-			return fmt.Errorf("Unrecognized operation: %v", r.Kind)
+			return fmt.Errorf("unrecognized operation: %v", r.Kind)
 		}
 
 	}
@@ -94,7 +94,7 @@ func (s DefaultUserSyncStrategy) createPgUser(user spec.PgUser, db *sql.DB) (err
 
 	_, err = db.Query(query) // TODO: Try several times
 	if err != nil {
-		err = fmt.Errorf("DB error: %s, query: %s", err, query)
+		err = fmt.Errorf("dB error: %s, query: %v", err, query)
 		return
 	}
 
@@ -116,7 +116,7 @@ func (s DefaultUserSyncStrategy) alterPgUser(user spec.PgUser, db *sql.DB) (err 
 
 	_, err = db.Query(query) // TODO: Try several times
 	if err != nil {
-		err = fmt.Errorf("DB error: %s query %s", err, query)
+		err = fmt.Errorf("dB error: %s query %v", err, query)
 		return
 	}
 


### PR DESCRIPTION
Use lowercase for kubernetes objects
Use %v instead of %s for errors
Start error messages with a lowercase letter.