### PR TITLE
Reset cluster error on successful update or sync

### DIFF
--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -132,6 +132,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 
 			return nil
 		}
+		cl.Error = nil
 		logger.Infof("Cluster '%s' has been updated", clusterName)
 	case spec.EventDelete:
 		logger.Infof("Deletion of the '%s' cluster started", clusterName)
@@ -171,6 +172,7 @@ func (c *Controller) processEvent(obj interface{}) error {
 			logger.Errorf("%v", cl)
 			return nil
 		}
+		cl.Error = nil
 
 		logger.Infof("Cluster '%s' has been synced", clusterName)
 	}


### PR DESCRIPTION
if cluster got repaired during the update or sync we need to reset Error field of the cluster object 