### PR TITLE
Implement replicaLoadBalancer boolean flag.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -155,8 +155,6 @@ func (c *Cluster) initUsers() error {
 		return fmt.Errorf("could not init human users: %v", err)
 	}
 
-	c.logger.Debugf("Initialized users: %# v", util.Pretty(c.pgUsers))
-
 	return nil
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -45,7 +45,7 @@ type Config struct {
 }
 
 type kubeResources struct {
-	Service     *v1.Service
+	Service     map[PostgresRole]*v1.Service
 	Endpoint    *v1.Endpoints
 	Secrets     map[types.UID]*v1.Secret
 	Statefulset *v1beta1.StatefulSet
@@ -79,7 +79,7 @@ type compareStatefulsetResult struct {
 
 func New(cfg Config, pgSpec spec.Postgresql, logger *logrus.Entry) *Cluster {
 	lg := logger.WithField("pkg", "cluster").WithField("cluster-name", pgSpec.Metadata.Name)
-	kubeResources := kubeResources{Secrets: make(map[types.UID]*v1.Secret)}
+	kubeResources := kubeResources{Secrets: make(map[types.UID]*v1.Secret), Service: make(map[PostgresRole]*v1.Service)}
 	orphanDependents := true
 
 	podEventsQueue := cache.NewFIFO(func(obj interface{}) (string, error) {
@@ -182,11 +182,16 @@ func (c *Cluster) Create() error {
 	}
 	c.logger.Infof("endpoint '%s' has been successfully created", util.NameFromMeta(ep.ObjectMeta))
 
-	service, err := c.createService()
-	if err != nil {
-		return fmt.Errorf("could not create service: %v", err)
+	for _, role := range []PostgresRole{Master, Replica} {
+		if role == Replica && !c.Spec.ReplicaLoadBalancer {
+			continue
+		}
+		service, err := c.createService(role)
+		if err != nil {
+			return fmt.Errorf("could not create %s service: %v", role, err)
+		}
+		c.logger.Infof("%s service '%s' has been successfully created", role, util.NameFromMeta(service.ObjectMeta))
 	}
-	c.logger.Infof("service '%s' has been successfully created", util.NameFromMeta(service.ObjectMeta))
 
 	if err = c.initUsers(); err != nil {
 		return err
@@ -234,10 +239,10 @@ func (c *Cluster) Create() error {
 	return nil
 }
 
-func (c *Cluster) sameServiceWith(service *v1.Service) (match bool, reason string) {
+func (c *Cluster) sameServiceWith(role PostgresRole, service *v1.Service) (match bool, reason string) {
 	//TODO: improve comparison
-	if !reflect.DeepEqual(c.Service.Spec.LoadBalancerSourceRanges, service.Spec.LoadBalancerSourceRanges) {
-		reason = "new service's LoadBalancerSourceRange doesn't match the current one"
+	if !reflect.DeepEqual(c.Service[role].Spec.LoadBalancerSourceRanges, service.Spec.LoadBalancerSourceRanges) {
+		reason = fmt.Sprintf("new %s service's LoadBalancerSourceRange doesn't match the current one", role)
 	} else {
 		match = true
 	}
@@ -385,14 +390,41 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 	c.logger.Debugf("Cluster update from version %s to %s",
 		c.Metadata.ResourceVersion, newSpec.Metadata.ResourceVersion)
 
-	newService := c.genService(newSpec.Spec.AllowedSourceRanges)
-	if match, reason := c.sameServiceWith(newService); !match {
-		c.logServiceChanges(c.Service, newService, true, reason)
-		if err := c.updateService(newService); err != nil {
-			c.setStatus(spec.ClusterStatusUpdateFailed)
-			return fmt.Errorf("could not update service: %v", err)
+	for _, role := range []PostgresRole{Master, Replica} {
+		if role == Replica {
+			if !newSpec.Spec.ReplicaLoadBalancer {
+				// old spec had a load balancer, but the new one doesn't
+				if c.Spec.ReplicaLoadBalancer {
+					err := c.deleteService(role)
+					if err != nil {
+						return fmt.Errorf("could not delete obsolete %s service: %v", role, err)
+					}
+					c.logger.Infof("deleted obsolete %s service", role)
+				}
+			} else {
+				if !c.Spec.ReplicaLoadBalancer {
+					// old spec didn't have a load balancer, but the one does
+					service, err := c.createService(role)
+					if err != nil {
+						return fmt.Errorf("could not create new %s service: %v", role, err)
+					}
+					c.logger.Infof("%s service '%s' has been created", role, util.NameFromMeta(service.ObjectMeta))
+				}
+			}
+			// only proceeed further if both old and new load balancer were present
+			if !(newSpec.Spec.ReplicaLoadBalancer && c.Spec.ReplicaLoadBalancer) {
+				continue
+			}
 		}
-		c.logger.Infof("service '%s' has been updated", util.NameFromMeta(c.Service.ObjectMeta))
+		newService := c.genService(role, newSpec.Spec.AllowedSourceRanges)
+		if match, reason := c.sameServiceWith(role, newService); !match {
+			c.logServiceChanges(role, c.Service[role], newService, true, reason)
+			if err := c.updateService(role, newService); err != nil {
+				c.setStatus(spec.ClusterStatusUpdateFailed)
+				return fmt.Errorf("could not update %s service: %v", role, err)
+			}
+			c.logger.Infof("%s service '%s' has been updated", role, util.NameFromMeta(c.Service[role].ObjectMeta))
+		}
 	}
 
 	newStatefulSet, err := c.genStatefulSet(newSpec.Spec)
@@ -456,8 +488,13 @@ func (c *Cluster) Delete() error {
 		return fmt.Errorf("could not delete endpoint: %v", err)
 	}
 
-	if err := c.deleteService(); err != nil {
-		return fmt.Errorf("could not delete service: %v", err)
+	for _, role := range []PostgresRole{Master, Replica} {
+		if role == Replica && !c.Spec.ReplicaLoadBalancer {
+			continue
+		}
+		if err := c.deleteService(role); err != nil {
+			return fmt.Errorf("could not delete %s service: %v", role, err)
+		}
 	}
 
 	if err := c.deleteStatefulSet(); err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -390,6 +390,11 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 	c.logger.Debugf("Cluster update from version %s to %s",
 		c.Metadata.ResourceVersion, newSpec.Metadata.ResourceVersion)
 
+	/* Make sure we update when this function exists */
+	defer func() {
+		c.Postgresql = *newSpec
+	}()
+
 	for _, role := range []PostgresRole{Master, Replica} {
 		if role == Replica {
 			if !newSpec.Spec.ReplicaLoadBalancer {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	PGBinariesLocationTemplate       = "/usr/lib/postgresql/%s/bin"
-	PatroniPGBinariesParameterName   = "pg_bin"
+	PatroniPGBinariesParameterName   = "bin_dir"
 	PatroniPGParametersParameterName = "parameters"
 )
 

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -438,7 +438,7 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
 			Namespace: c.Metadata.Namespace,
-			Labels:    c.labelsSet(),
+			Labels:    c.roleLabelsSet(role),
 			Annotations: map[string]string{
 				constants.ZalandoDNSNameAnnotation: dnsNameFunction(),
 				constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
@@ -457,12 +457,12 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 	return service
 }
 
-func (c *Cluster) genEndpoints() *v1.Endpoints {
+func (c *Cluster) genMasterEndpoints() *v1.Endpoints {
 	endpoints := &v1.Endpoints{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      c.Metadata.Name,
 			Namespace: c.Metadata.Namespace,
-			Labels:    c.labelsSet(),
+			Labels:    c.roleLabelsSet(Master),
 		},
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -205,7 +205,7 @@ func (c *Cluster) SyncRoles() error {
 func (c *Cluster) SyncVolumes() error {
 	act, err := c.VolumesNeedResizing(c.Spec.Volume)
 	if err != nil {
-		return fmt.Errorf("could not check compare size of the volumes: %v", err)
+		return fmt.Errorf("could not compare size of the volumes: %v", err)
 	}
 	if !act {
 		return nil

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -1,0 +1,8 @@
+package cluster
+
+type PostgresRole string
+
+const (
+	Master  PostgresRole = "master"
+	Replica PostgresRole = "replica"
+)

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -263,10 +263,19 @@ func (c *Cluster) waitStatefulsetPodsReady() error {
 }
 
 func (c *Cluster) labelsSet() labels.Set {
-	lbls := c.OpConfig.ClusterLabels
+	lbls := make(map[string]string)
+	for k, v := range(c.OpConfig.ClusterLabels) {
+		lbls[k] = v
+	}
 	lbls[c.OpConfig.ClusterNameLabel] = c.Metadata.Name
 
 	return labels.Set(lbls)
+}
+
+func (c *Cluster) roleLabelsSet(role PostgresRole) labels.Set {
+	lbls := c.labelsSet()
+	lbls[c.OpConfig.PodRoleLabel] = string(role)
+	return lbls
 }
 
 func (c *Cluster) masterDnsName() string {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -145,7 +145,6 @@ func (c *Cluster) getTeamMembers() ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get team info: %v", err)
 	}
-	c.logger.Debugf("Got from the Team API: %+v", *teamInfo)
 
 	return teamInfo.Members, nil
 }

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -264,7 +264,7 @@ func (c *Cluster) waitStatefulsetPodsReady() error {
 
 func (c *Cluster) labelsSet() labels.Set {
 	lbls := make(map[string]string)
-	for k, v := range(c.OpConfig.ClusterLabels) {
+	for k, v := range c.OpConfig.ClusterLabels {
 		lbls[k] = v
 	}
 	lbls[c.OpConfig.ClusterNameLabel] = c.Metadata.Name

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -82,14 +82,14 @@ func (c *Cluster) logStatefulSetChanges(old, new *v1beta1.StatefulSet, isUpdate 
 	}
 }
 
-func (c *Cluster) logServiceChanges(old, new *v1.Service, isUpdate bool, reason string) {
+func (c *Cluster) logServiceChanges(role PostgresRole, old, new *v1.Service, isUpdate bool, reason string) {
 	if isUpdate {
-		c.logger.Infof("service '%s' has been changed",
-			util.NameFromMeta(old.ObjectMeta),
+		c.logger.Infof("%s service '%s' has been changed",
+			role, util.NameFromMeta(old.ObjectMeta),
 		)
 	} else {
-		c.logger.Infof("service '%s  is not in the desired state and needs to be updated",
-			util.NameFromMeta(old.ObjectMeta),
+		c.logger.Infof("%s service '%s  is not in the desired state and needs to be updated",
+			role, util.NameFromMeta(old.ObjectMeta),
 		)
 	}
 	c.logger.Debugf("diff\n%s\n", util.PrettyDiff(old.Spec, new.Spec))
@@ -269,8 +269,15 @@ func (c *Cluster) labelsSet() labels.Set {
 	return labels.Set(lbls)
 }
 
-func (c *Cluster) dnsName() string {
-	return strings.ToLower(c.OpConfig.DNSNameFormat.Format(
+func (c *Cluster) masterDnsName() string {
+	return strings.ToLower(c.OpConfig.MasterDNSNameFormat.Format(
+		"cluster", c.Spec.ClusterName,
+		"team", c.teamName(),
+		"hostedzone", c.OpConfig.DbHostedZone))
+}
+
+func (c *Cluster) replicaDnsName() string {
+	return strings.ToLower(c.OpConfig.ReplicaDNSNameFormat.Format(
 		"cluster", c.Spec.ClusterName,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -79,6 +79,7 @@ type PostgresSpec struct {
 
 	TeamID              string               `json:"teamId"`
 	AllowedSourceRanges []string             `json:"allowedSourceRanges"`
+	ReplicaLoadBalancer bool                 `json:"replicaLoadBalancer,omitempty"`
 	NumberOfInstances   int32                `json:"numberOfInstances"`
 	Users               map[string]UserFlags `json:"users"`
 	MaintenanceWindows  []MaintenanceWindow  `json:"maintenanceWindows,omitempty"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -43,19 +43,20 @@ type Config struct {
 	TPR
 	Resources
 	Auth
-	Namespace          string         `name:"namespace"`
-	EtcdHost           string         `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
-	DockerImage        string         `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
-	ServiceAccountName string         `name:"service_account_name" default:"operator"`
-	DbHostedZone       string         `name:"db_hosted_zone" default:"db.example.com"`
-	EtcdScope          string         `name:"etcd_scope" default:"service"`
-	WALES3Bucket       string         `name:"wal_s3_bucket"`
-	KubeIAMRole        string         `name:"kube_iam_role"`
-	DebugLogging       bool           `name:"debug_logging" default:"true"`
-	EnableDBAccess     bool           `name:"enable_database_access" default:"true"`
-	EnableTeamsAPI     bool           `name:"enable_teams_api" default:"true"`
-	DNSNameFormat      stringTemplate `name:"dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
-	Workers            uint32         `name:"workers" default:"4"`
+	Namespace            string         `name:"namespace"`
+	EtcdHost             string         `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
+	DockerImage          string         `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
+	ServiceAccountName   string         `name:"service_account_name" default:"operator"`
+	DbHostedZone         string         `name:"db_hosted_zone" default:"db.example.com"`
+	EtcdScope            string         `name:"etcd_scope" default:"service"`
+	WALES3Bucket         string         `name:"wal_s3_bucket"`
+	KubeIAMRole          string         `name:"kube_iam_role"`
+	DebugLogging         bool           `name:"debug_logging" default:"true"`
+	EnableDBAccess       bool           `name:"enable_database_access" default:"true"`
+	EnableTeamsAPI       bool           `name:"enable_teams_api" default:"true"`
+	MasterDNSNameFormat  stringTemplate `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
+	ReplicaDNSNameFormat stringTemplate `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
+	Workers              uint32         `name:"workers" default:"4"`
 }
 
 func (c Config) MustMarshal() string {


### PR DESCRIPTION
The new configuration flag adds a replica service with the name 
cluster_name-repl and a DNS name that defaults to {cluster}-repl.{team}.{hostedzone}.

The implementation converted Service field of the cluster into a map
with one or two elements and deals with the cases when the new flag
is changed on a running cluster (the update and the sync should create or delete the replica service).