### PR TITLE
Replace service annotations when updating services.

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -281,7 +281,6 @@ func (c *Cluster) updateService(role PostgresRole, newService *v1.Service) error
 	return nil
 }
 
-
 func (c *Cluster) deleteService(role PostgresRole) error {
 	c.logger.Debugf("Deleting service %s", role)
 	if c.Service[role] == nil {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -70,7 +70,8 @@ func metadataAnnotationsPatch(annotations map[string]string) string {
 		annotationsList = append(annotationsList, fmt.Sprintf(`"%s":"%s"`, name, value))
 	}
 	annotationsString := strings.Join(annotationsList, ",")
-	return fmt.Sprintf(`{"metadata":{"annotations": {"$patch":"replace", %s}}}`, annotationsString)
+	// TODO: perhaps use patchStrategy:"replace" json annotation instead of constructing the patch literally.
+	return fmt.Sprintf(constants.ServiceMetadataAnnotationFormat, annotationsString)
 }
 
 func (c *Cluster) logStatefulSetChanges(old, new *v1beta1.StatefulSet, isUpdate bool, reasons []string) {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -63,10 +63,10 @@ func specPatch(spec interface{}) ([]byte, error) {
 	}{spec})
 }
 
-func metadataAnnotationsPatch(annotations map[string]string) (string) {
+func metadataAnnotationsPatch(annotations map[string]string) string {
 	annotationsList := make([]string, 0, len(annotations))
 
-	for name, value := range(annotations) {
+	for name, value := range annotations {
 		annotationsList = append(annotationsList, fmt.Sprintf(`"%s":"%s"`, name, value))
 	}
 	annotationsString := strings.Join(annotationsList, ",")

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -63,6 +63,16 @@ func specPatch(spec interface{}) ([]byte, error) {
 	}{spec})
 }
 
+func metadataAnnotationsPatch(annotations map[string]string) (string) {
+	annotationsList := make([]string, 0, len(annotations))
+
+	for name, value := range(annotations) {
+		annotationsList = append(annotationsList, fmt.Sprintf(`"%s":"%s"`, name, value))
+	}
+	annotationsString := strings.Join(annotationsList, ",")
+	return fmt.Sprintf(`{"metadata":{"annotations": {"$patch":"replace", %s}}}`, annotationsString)
+}
+
 func (c *Cluster) logStatefulSetChanges(old, new *v1beta1.StatefulSet, isUpdate bool, reasons []string) {
 	if isUpdate {
 		c.logger.Infof("statefulset '%s' has been changed",

--- a/pkg/util/constants/annotations.go
+++ b/pkg/util/constants/annotations.go
@@ -7,4 +7,5 @@ const (
 	ElbTimeoutAnnotationValue          = "3600"
 	KubeIAmAnnotation                  = "iam.amazonaws.com/role"
 	VolumeStorateProvisionerAnnotation = "pv.kubernetes.io/provisioned-by"
+	ServiceMetadataAnnotationFormat    = `{"metadata":{"annotations": {"$patch":"replace", %s}}}`
 )


### PR DESCRIPTION
In case the whole annotation changes (like the external DNS) we
don't want to keep the old one hanging around. Unline specs, we
don't expect anyone except the operator to change the annotations.

Use StrategicMergePatchType in order to replace the annotations
map completely.

This fixes #45 