### PR TITLE
WIP: Restrict LB by default

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -436,6 +436,7 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 	}
 
 	serviceSpec := v1.ServiceSpec{}
+	var annotations map[string]string
 
 	if c.OpConfig.EnableLoadBalancer {
 		// safe default value: lock load balancer to only local address unless overriden explicitely.
@@ -450,6 +451,11 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 			LoadBalancerSourceRanges: sourceRanges,
 		}
 
+		annotations = map[string]string{
+			constants.ZalandoDNSNameAnnotation: dnsNameFunction(),
+			constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
+		}
+
 		if role == Replica {
 			serviceSpec.Selector = map[string]string{c.OpConfig.PodRoleLabel: string(Replica)}
 		}
@@ -460,10 +466,7 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 			Name:      name,
 			Namespace: c.Metadata.Namespace,
 			Labels:    c.roleLabelsSet(role),
-			Annotations: map[string]string{
-				constants.ZalandoDNSNameAnnotation: dnsNameFunction(),
-				constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
-			},
+			Annotations: annotations,
 		},
 		Spec: serviceSpec,
 	}

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -435,7 +435,9 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 		name = name + "-repl"
 	}
 
-	serviceSpec := v1.ServiceSpec{}
+	serviceSpec := v1.ServiceSpec{
+		Ports:	[]v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
+	}
 	var annotations map[string]string
 
 	if c.OpConfig.EnableLoadBalancer {
@@ -445,11 +447,8 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 			sourceRanges = allowedSourceRanges
 		}
 
-		serviceSpec = v1.ServiceSpec{
-			Type:  v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
-			LoadBalancerSourceRanges: sourceRanges,
-		}
+		serviceSpec.Type = v1.ServiceTypeLoadBalancer
+		serviceSpec.LoadBalancerSourceRanges = sourceRanges
 
 		annotations = map[string]string{
 			constants.ZalandoDNSNameAnnotation: dnsNameFunction(),

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -434,6 +434,12 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 		name = name + "-repl"
 	}
 
+	// safe default value: lock load balancer to only local address unless overriden explicitely.
+	sourceRanges := []string{"127.0.0.1/32"}
+	if len(allowedSourceRanges) >= 0 {
+		sourceRanges = allowedSourceRanges
+	}
+
 	service := &v1.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
@@ -447,7 +453,7 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 		Spec: v1.ServiceSpec{
 			Type:  v1.ServiceTypeLoadBalancer,
 			Ports: []v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
-			LoadBalancerSourceRanges: allowedSourceRanges,
+			LoadBalancerSourceRanges: sourceRanges,
 		},
 	}
 	if role == Replica {

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -1,9 +1,9 @@
 package spec
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
-	"database/sql"
 
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/types"

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	DebugLogging         bool           `name:"debug_logging" default:"true"`
 	EnableDBAccess       bool           `name:"enable_database_access" default:"true"`
 	EnableTeamsAPI       bool           `name:"enable_teams_api" default:"true"`
+	EnableLoadBalancer   bool           `name:"enable_load_balancer" default:"true"`
 	MasterDNSNameFormat  stringTemplate `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
 	ReplicaDNSNameFormat stringTemplate `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
 	Workers              uint32         `name:"workers" default:"4"`


### PR DESCRIPTION
if allowedSourceRanges is not specified - lock down the load balancer to accept only local connections for security reasons.
Allow enabling/disabling the load balancer on the operator level.