### PR TITLE
Make load balancer configurable

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -28,3 +28,4 @@ data:
   super_username: postgres
   teams_api_url: http://fake-teams-api.default.svc.cluster.local
   workers: "4"
+  enable_load_balancer: "true"

--- a/manifests/testpostgresql.yaml
+++ b/manifests/testpostgresql.yaml
@@ -41,6 +41,7 @@ spec:
     loop_wait: &loop_wait 10
     retry_timeout: 10
     maximum_lag_on_failover: 33554432
+    useLoadBalancer: true
   maintenanceWindows:
   - 01:00-06:00 #UTC
   - Sat:00:00-04:00

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -435,7 +435,7 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 				continue
 			}
 		}
-		newService := c.genService(role, newSpec.Spec.AllowedSourceRanges)
+		newService := c.genService(role, &newSpec.Spec)
 		if match, reason := c.sameServiceWith(role, newService); !match {
 			c.logServiceChanges(role, c.Service[role], newService, true, reason)
 			if err := c.updateService(role, newService); err != nil {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -436,6 +436,7 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 	}
 
 	serviceSpec := v1.ServiceSpec{}
+	var annotations map[string]string
 
 	if c.OpConfig.EnableLoadBalancer {
 		// safe default value: lock load balancer to only local address unless overriden explicitely.
@@ -450,6 +451,11 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 			LoadBalancerSourceRanges: sourceRanges,
 		}
 
+		annotations = map[string]string{
+			constants.ZalandoDNSNameAnnotation: dnsNameFunction(),
+			constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
+		}
+
 		if role == Replica {
 			serviceSpec.Selector = map[string]string{c.OpConfig.PodRoleLabel: string(Replica)}
 		}
@@ -460,10 +466,7 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 			Name:      name,
 			Namespace: c.Metadata.Namespace,
 			Labels:    c.roleLabelsSet(role),
-			Annotations: map[string]string{
-				constants.ZalandoDNSNameAnnotation: dnsNameFunction(),
-				constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
-			},
+			Annotations: annotations,
 		},
 		Spec: serviceSpec,
 	}

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -435,7 +435,9 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 		name = name + "-repl"
 	}
 
-	serviceSpec := v1.ServiceSpec{}
+	serviceSpec := v1.ServiceSpec{
+		Ports:	[]v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
+	}
 	var annotations map[string]string
 
 	if c.OpConfig.EnableLoadBalancer {
@@ -445,11 +447,8 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 			sourceRanges = allowedSourceRanges
 		}
 
-		serviceSpec = v1.ServiceSpec{
-			Type:  v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
-			LoadBalancerSourceRanges: sourceRanges,
-		}
+		serviceSpec.Type = v1.ServiceTypeLoadBalancer
+		serviceSpec.LoadBalancerSourceRanges = sourceRanges
 
 		annotations = map[string]string{
 			constants.ZalandoDNSNameAnnotation: dnsNameFunction(),

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -434,6 +434,12 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 		name = name + "-repl"
 	}
 
+	// safe default value: lock load balancer to only local address unless overriden explicitely.
+	sourceRanges := []string{"127.0.0.1/32"}
+	if len(allowedSourceRanges) >= 0 {
+		sourceRanges = allowedSourceRanges
+	}
+
 	service := &v1.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
@@ -447,7 +453,7 @@ func (c *Cluster) genService(role PostgresRole, allowedSourceRanges []string) *v
 		Spec: v1.ServiceSpec{
 			Type:  v1.ServiceTypeLoadBalancer,
 			Ports: []v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
-			LoadBalancerSourceRanges: allowedSourceRanges,
+			LoadBalancerSourceRanges: sourceRanges,
 		},
 	}
 	if role == Replica {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -100,7 +100,7 @@ func (c *Cluster) syncService(role PostgresRole) error {
 		return nil
 	}
 
-	desiredSvc := c.genService(role, cSpec.AllowedSourceRanges)
+	desiredSvc := c.genService(role, &cSpec)
 	match, reason := c.sameServiceWith(role, desiredSvc)
 	if match {
 		return nil

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -70,8 +70,8 @@ func metadataAnnotationsPatch(annotations map[string]string) string {
 		annotationsList = append(annotationsList, fmt.Sprintf(`"%s":"%s"`, name, value))
 	}
 	annotationsString := strings.Join(annotationsList, ",")
-	// TODO: perhaps use patchStrategy:"replace" json annotation instead of constructing the patch literally.
-	return fmt.Sprintf(constants.ServiceMetadataAnnotationFormat, annotationsString)
+	// TODO: perhaps use patchStrategy:action json annotation instead of constructing the patch literally.
+	return fmt.Sprintf(constants.ServiceMetadataAnnotationReplaceFormat, annotationsString)
 }
 
 func (c *Cluster) logStatefulSetChanges(old, new *v1beta1.StatefulSet, isUpdate bool, reasons []string) {

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -86,8 +86,10 @@ type PostgresSpec struct {
 	Patroni         `json:"patroni,omitempty"`
 	Resources       `json:"resources,omitempty"`
 
-	TeamID              string               `json:"teamId"`
-	AllowedSourceRanges []string             `json:"allowedSourceRanges"`
+	TeamID              string   `json:"teamId"`
+	AllowedSourceRanges []string `json:"allowedSourceRanges"`
+	// EnableLoadBalancer  is a pointer, since it is importat to know if that parameters is omited from the manifest
+	UseLoadBalancer     *bool                `json:"useLoadBalancer,omitempty"`
 	ReplicaLoadBalancer bool                 `json:"replicaLoadBalancer,omitempty"`
 	NumberOfInstances   int32                `json:"numberOfInstances"`
 	Users               map[string]userFlags `json:"users"`

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -1,9 +1,9 @@
 package spec
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
-	"database/sql"
 
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/types"

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	DebugLogging         bool           `name:"debug_logging" default:"true"`
 	EnableDBAccess       bool           `name:"enable_database_access" default:"true"`
 	EnableTeamsAPI       bool           `name:"enable_teams_api" default:"true"`
+	EnableLoadBalancer   bool           `name:"enable_load_balancer" default:"true"`
 	MasterDNSNameFormat  stringTemplate `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
 	ReplicaDNSNameFormat stringTemplate `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
 	Workers              uint32         `name:"workers" default:"4"`

--- a/pkg/util/constants/annotations.go
+++ b/pkg/util/constants/annotations.go
@@ -2,10 +2,10 @@ package constants
 
 // Names and values in Kubernetes annotation for services, statefulsets and volumes
 const (
-	ZalandoDNSNameAnnotation           = "external-dns.alpha.kubernetes.io/hostname"
-	ElbTimeoutAnnotationName           = "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"
-	ElbTimeoutAnnotationValue          = "3600"
-	KubeIAmAnnotation                  = "iam.amazonaws.com/role"
-	VolumeStorateProvisionerAnnotation = "pv.kubernetes.io/provisioned-by"
-	ServiceMetadataAnnotationFormat    = `{"metadata":{"annotations": {"$patch":"replace", %s}}}`
+	ZalandoDNSNameAnnotation               = "external-dns.alpha.kubernetes.io/hostname"
+	ElbTimeoutAnnotationName               = "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"
+	ElbTimeoutAnnotationValue              = "3600"
+	KubeIAmAnnotation                      = "iam.amazonaws.com/role"
+	VolumeStorateProvisionerAnnotation     = "pv.kubernetes.io/provisioned-by"
+	ServiceMetadataAnnotationReplaceFormat = `{"metadata":{"annotations": {"$patch":"replace", %s}}}`
 )


### PR DESCRIPTION
- Make the load balancer configurable on a per cluster and operator-wide level
- restrict connections to clusters with the load balancers but without ``allowedSourceRanges`` defined.

Addresses #54 

