### PR TITLE
Avoid re-creating master pod if it is empty

### DIFF
--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -140,14 +140,14 @@ func (c *Cluster) recreatePods() error {
 	}
 	if masterPod.Name == "" {
 		c.logger.Warningln("No master pod in the cluster")
-	}
+	} else {
+		//TODO: do manual failover
+		//TODO: specify master, leave new master empty
+		c.logger.Infof("Recreating master pod '%s'", util.NameFromMeta(masterPod.ObjectMeta))
 
-	//TODO: do manual failover
-	//TODO: specify master, leave new master empty
-	c.logger.Infof("Recreating master pod '%s'", util.NameFromMeta(masterPod.ObjectMeta))
-
-	if err := c.recreatePod(masterPod); err != nil {
-		return fmt.Errorf("could not recreate master pod '%s': %v", util.NameFromMeta(masterPod.ObjectMeta), err)
+		if err := c.recreatePod(masterPod); err != nil {
+			return fmt.Errorf("could not recreate master pod '%s': %v", util.NameFromMeta(masterPod.ObjectMeta), err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Avoid error messages like this one:

time="2017-07-12T07:35:37Z" level=info msg="Recreating master pod '/'" cluster-name=team-example pkg=cluster worker=2
time="2017-07-12T07:35:37Z" level=error msg="could not sync cluster 'default/team-example': could not sync statefulsets: could not recreate pods: could not recreate master pod '/': could not delete pod: resource name may not be empty" pkg=controller worker=2