### PR TITLE
Bugfix/close db connections

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -143,6 +143,7 @@ func (c *Cluster) setStatus(status spec.PostgresStatus) {
 	}
 }
 
+// initUsers populates c.systemUsers and c.pgUsers maps.
 func (c *Cluster) initUsers() error {
 	c.initSystemUsers()
 
@@ -204,7 +205,7 @@ func (c *Cluster) Create() error {
 	if err = c.initUsers(); err != nil {
 		return err
 	}
-	c.logger.Infof("User secrets have been initialized")
+	c.logger.Infof("Users have been initialized")
 
 	if err = c.applySecrets(); err != nil {
 		return fmt.Errorf("could not create secrets: %v", err)
@@ -226,11 +227,7 @@ func (c *Cluster) Create() error {
 	c.logger.Infof("pods are ready")
 
 	if !(c.masterLess || c.databaseAccessDisabled()) {
-		err = c.initDbConn()
-		if err != nil {
-			return fmt.Errorf("could not init db connection: %v", err)
-		}
-		err = c.createUsers()
+		err = c.createRoles()
 		if err != nil {
 			return fmt.Errorf("could not create users: %v", err)
 		}

--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -46,6 +46,7 @@ func (c *Cluster) initDbConn() (err error) {
 		if err != nil {
 			return err
 		}
+		c.logger.Debug("new database connection")
 		err = conn.Ping()
 		if err != nil {
 			if err2 := conn.Close(); err2 != nil {
@@ -57,6 +58,15 @@ func (c *Cluster) initDbConn() (err error) {
 		c.pgDb = conn
 	}
 
+	return nil
+}
+
+func (c *Cluster) closeDbConn() (err error) {
+	if c.pgDb != nil {
+		c.logger.Debug("closing database connection")
+		return c.pgDb.Close()
+	}
+	c.logger.Warning("attempted to close an empty db connection object")
 	return nil
 }
 

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -415,10 +415,7 @@ func (c *Cluster) deleteSecret(secret *v1.Secret) error {
 	return err
 }
 
-func (c *Cluster) createUsers() (err error) {
+func (c *Cluster) createRoles() (err error) {
 	// TODO: figure out what to do with duplicate names (humans and robots) among pgUsers
-	reqs := c.userSyncStrategy.ProduceSyncRequests(nil, c.pgUsers)
-	err = c.userSyncStrategy.ExecuteSyncRequests(reqs, c.pgDb)
-
-	return err
+	return c.syncRoles(false)
 }

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -32,7 +32,7 @@ type Resources struct {
 
 // Auth describes authentication specific configuration parameters
 type Auth struct {
-	PamRoleName                   string              `name:"pam_rol_name" default:"zalandos"`
+	PamRoleName                   string              `name:"pam_role_name" default:"zalandos"`
 	PamConfiguration              string              `name:"pam_configuration" default:"https://info.example.com/oauth2/tokeninfo?access_token= uid realm=/employees"`
 	TeamsAPIUrl                   string              `name:"teams_api_url" default:"https://teams.example.com/api/"`
 	OAuthTokenSecretName          spec.NamespacedName `name:"oauth_token_secret_name" default:"postgresql-operator"`


### PR DESCRIPTION
Previously, we used to leave the DB connection open while the
cluster was registered with the operator, potentially resutling
in dangled connections if the operator terminates abnormally.

Small refactoring around the role syncing code.