### PR TITLE
Move controller config to the spec package 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/zalando-incubator/postgres-operator/pkg/controller"
+	"github.com/zalando-incubator/postgres-operator/pkg/spec"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/k8sutil"
 )
 
@@ -16,7 +17,7 @@ var (
 	kubeConfigFile string
 	outOfCluster   bool
 	version        string
-	config         controller.Config
+	config         spec.ControllerConfig
 )
 
 func init() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,20 +17,9 @@ import (
 	"github.com/zalando-incubator/postgres-operator/pkg/util/k8sutil"
 )
 
-// Config describes configuration of the controller
-type Config struct {
-	RestConfig          *rest.Config
-	InfrastructureRoles map[string]spec.PgUser
-
-	NoDatabaseAccess bool
-	NoTeamsAPI       bool
-	ConfigMapName    spec.NamespacedName
-	Namespace        string
-}
-
 // Controller represents operator controller
 type Controller struct {
-	config   Config
+	config   spec.ControllerConfig
 	opConfig *config.Config
 
 	logger     *logrus.Entry
@@ -45,22 +34,23 @@ type Controller struct {
 	podInformer        cache.SharedIndexInformer
 	podCh              chan spec.PodEvent
 
-	clusterEventQueues  []*cache.FIFO
+	clusterEventQueues  []*cache.FIFO // [workerID]Queue
 	lastClusterSyncTime int64
 }
 
 // NewController creates a new controller
-func NewController(controllerConfig *Config) *Controller {
+func NewController(controllerConfig *spec.ControllerConfig) *Controller {
 	logger := logrus.New()
 
-	return &Controller{
+	c := &Controller{
 		config:   *controllerConfig,
 		opConfig: &config.Config{},
 		logger:   logger.WithField("pkg", "controller"),
 		clusters: make(map[spec.NamespacedName]*cluster.Cluster),
-		stopChs:  make(map[spec.NamespacedName]chan struct{}),
 		podCh:    make(chan spec.PodEvent),
 	}
+
+	return c
 }
 
 func (c *Controller) initClients() {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -48,7 +48,7 @@ func newMockKubernetesClient() k8sutil.KubernetesClient {
 }
 
 func newMockController() *Controller {
-	controller := NewController(&Config{})
+	controller := NewController(&spec.ControllerConfig{})
 	controller.opConfig.ClusterNameLabel = "cluster-name"
 	controller.opConfig.InfrastructureRolesSecretName =
 		spec.NamespacedName{Namespace: v1.NamespaceDefault, Name: testInfrastructureRolesSecretName}

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
 )
 
 // EventType contains type of the events for the TPRs and Pods received from Kubernetes
@@ -70,6 +71,17 @@ type PgSyncUserRequest struct {
 type UserSyncer interface {
 	ProduceSyncRequests(dbUsers PgUserMap, newUsers PgUserMap) (req []PgSyncUserRequest)
 	ExecuteSyncRequests(req []PgSyncUserRequest, db *sql.DB) error
+}
+
+// ControllerConfig describes configuration of the controller
+type ControllerConfig struct {
+	RestConfig          *rest.Config `json:"-"`
+	InfrastructureRoles map[string]PgUser
+
+	NoDatabaseAccess bool
+	NoTeamsAPI       bool
+	ConfigMapName    NamespacedName
+	Namespace        string
 }
 
 func (n NamespacedName) String() string {


### PR DESCRIPTION
Moving config to the spec package will help us avoiding cyclic dependencies