### PR TITLE
Discard cluster events from the queue on cluster delete

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -93,7 +93,7 @@ func (s *Server) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 			s.logger.Fatalf("Could not start http server: %v", err)
 		}
 	}()
-	s.logger.Infof("Listening on %s", s.http.Addr)
+	s.logger.Infof("listening on %s", s.http.Addr)
 
 	<-stopCh
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -132,12 +132,12 @@ func (c *Cluster) setStatus(status spec.PostgresStatus) {
 		DoRaw()
 
 	if k8sutil.ResourceNotFound(err) {
-		c.logger.Warningf("could not set status for the non-existing cluster")
+		c.logger.Warningf("could not set %q status for the non-existing cluster", status)
 		return
 	}
 
 	if err != nil {
-		c.logger.Warningf("could not set status for the cluster: %v", err)
+		c.logger.Warningf("could not set %q status for the cluster: %v", status, err)
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -169,7 +170,7 @@ func (c *Controller) initController() {
 				return "", fmt.Errorf("could not cast to ClusterEvent")
 			}
 
-			return fmt.Sprintf("%s-%s", e.EventType, e.UID), nil
+			return queueClusterKey(e.EventType, e.UID), nil
 		})
 	}
 
@@ -205,4 +206,8 @@ func (c *Controller) runPostgresqlInformer(stopCh <-chan struct{}, wg *sync.Wait
 	defer wg.Done()
 
 	c.postgresqlInformer.Run(stopCh)
+}
+
+func queueClusterKey(eventType spec.EventType, uid types.UID) string {
+	return fmt.Sprintf("%s-%s", eventType, uid)
 }


### PR DESCRIPTION
If we delete a cluster we can discard all the events preceding to the deletion of the cluster