### PR TITLE
Worker queue size in the status api endpoint

### DIFF
--- a/pkg/controller/status.go
+++ b/pkg/controller/status.go
@@ -51,9 +51,15 @@ func (c *Controller) GetStatus() *spec.ControllerStatus {
 	clustersCnt := len(c.clusters)
 	c.clustersMu.RUnlock()
 
+	queueSizes := make(map[int]int, c.opConfig.Workers)
+	for workerID, queue := range c.clusterEventQueues {
+		queueSizes[workerID] = len(queue.ListKeys())
+	}
+
 	return &spec.ControllerStatus{
-		LastSyncTime: atomic.LoadInt64(&c.lastClusterSyncTime),
-		Clusters:     clustersCnt,
+		LastSyncTime:    atomic.LoadInt64(&c.lastClusterSyncTime),
+		Clusters:        clustersCnt,
+		WorkerQueueSize: queueSizes,
 	}
 }
 

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -102,8 +102,9 @@ type ClusterStatus struct {
 
 // ControllerStatus describes status of the controller
 type ControllerStatus struct {
-	LastSyncTime int64
-	Clusters     int
+	LastSyncTime    int64
+	Clusters        int
+	WorkerQueueSize map[int]int
 }
 
 // QueueDump describes cache.FIFO queue


### PR DESCRIPTION
Display size of the queue for each worker in the ``/status`` api endpoint