### PR TITLE
Allow cloning clusters from the operator.

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -21,7 +21,7 @@ data:
   pod_label_wait_timeout: 10m
   ready_wait_interval: 3s
   ready_wait_timeout: 30s
-  replication_username: replication
+  replication_username: standby
   resource_check_interval: 3s
   resource_check_timeout: 10m
   resync_period: 5m

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -442,7 +442,7 @@ func (c *Cluster) generateService(role postgresRole, newSpec *spec.PostgresSpec)
 	}
 
 	if role == replica {
-		serviceSpec.Selector = map[string]string{c.OpConfig.PodRoleLabel: string(replica)}
+		serviceSpec.Selector = c.roleLabelsSet(role)
 	}
 
 	var annotations map[string]string

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -285,7 +285,7 @@ func (c *Cluster) generatePodTemplate(resourceRequirements *v1.ResourceRequireme
 	container := v1.Container{
 		Name:            c.Name,
 		Image:           c.OpConfig.DockerImage,
-		ImagePullPolicy: v1.PullAlways,
+		ImagePullPolicy: v1.PullIfNotPresent,
 		Resources:       *resourceRequirements,
 		Ports: []v1.ContainerPort{
 			{
@@ -519,13 +519,14 @@ func (c *Cluster) generateCloneEnvironment(description *spec.CloneDescription) [
 		result = append(result, v1.EnvVar{Name: "CLONE_METHOD", Value: "CLONE_WITH_BASEBACKUP"})
 		result = append(result, v1.EnvVar{Name: "CLONE_HOST", Value: host})
 		result = append(result, v1.EnvVar{Name: "CLONE_PORT", Value: port})
-		result = append(result, v1.EnvVar{Name: "CLONE_USER", Value: c.OpConfig.SuperUsername})
+		// TODO: assume replication user name is the same for all clusters, fetch it from secrets otherwise
+		result = append(result, v1.EnvVar{Name: "CLONE_USER", Value: c.OpConfig.ReplicationUsername})
 		result = append(result,
 			v1.EnvVar{Name: "CLONE_PASSWORD",
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
-							Name: c.credentialSecretNameForCluster(c.OpConfig.SuperUsername,
+							Name: c.credentialSecretNameForCluster(c.OpConfig.ReplicationUsername,
 								description.ClusterName),
 						},
 						Key: "password",

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -341,7 +341,7 @@ func (c *Cluster) generateStatefulSet(spec spec.PostgresSpec) (*v1beta1.Stateful
 		return nil, err
 	}
 
-	podTemplate := c.generatePodTemplate(resourceRequirements, &spec.PostgresqlParam, &spec.Patroni, &spec.CloneDescription)
+	podTemplate := c.generatePodTemplate(resourceRequirements, &spec.PostgresqlParam, &spec.Patroni, &spec.Clone)
 	volumeClaimTemplate, err := generatePersistentVolumeClaimTemplate(spec.Volume.Size, spec.Volume.StorageClass)
 	if err != nil {
 		return nil, err

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -307,12 +307,12 @@ func (c *Cluster) credentialSecretName(username string) string {
 	return c.credentialSecretNameForCluster(username, c.Name)
 }
 
-func (c *Cluster) credentialSecretNameForCluster(username string, clustername string) string {
+func (c *Cluster) credentialSecretNameForCluster(username string, clusterName string) string {
 	// secret  must consist of lower case alphanumeric characters, '-' or '.',
 	// and must start and end with an alphanumeric character
 	return fmt.Sprintf(constants.UserSecretTemplate,
 		strings.Replace(username, "_", "-", -1),
-		clustername)
+		clusterName)
 }
 
 func (c *Cluster) podSpiloRole(pod *v1.Pod) string {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -304,11 +304,15 @@ func (c *Cluster) replicaDNSName() string {
 }
 
 func (c *Cluster) credentialSecretName(username string) string {
+	return c.credentialSecretNameForCluster(username, c.Name)
+}
+
+func (c *Cluster) credentialSecretNameForCluster(username string, clustername string) string {
 	// secret  must consist of lower case alphanumeric characters, '-' or '.',
 	// and must start and end with an alphanumeric character
 	return fmt.Sprintf(constants.UserSecretTemplate,
 		strings.Replace(username, "_", "-", -1),
-		c.Name)
+		clustername)
 }
 
 func (c *Cluster) podSpiloRole(pod *v1.Pod) string {

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -243,6 +243,13 @@ func (p *Postgresql) UnmarshalJSON(data []byte) error {
 		tmp2.Error = err
 		tmp2.Status = ClusterStatusInvalid
 	}
+	// The assumption below is that a cluster to clone, if any, belongs to the same team
+	if tmp2.Spec.Clone.ClusterName != "" {
+		_, err := extractClusterName(tmp2.Spec.Clone.ClusterName, tmp2.Spec.TeamID)
+		if err != nil {
+			tmp2.Error = fmt.Errorf(" %s for the cluster to clone")
+		}
+	}
 	*p = tmp2
 
 	return nil

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -85,10 +85,10 @@ type Postgresql struct {
 
 // PostgresSpec defines the specification for the PostgreSQL TPR.
 type PostgresSpec struct {
-	PostgresqlParam  `json:"postgresql"`
-	Volume           `json:"volume,omitempty"`
-	Patroni          `json:"patroni,omitempty"`
-	Resources        `json:"resources,omitempty"`
+	PostgresqlParam `json:"postgresql"`
+	Volume          `json:"volume,omitempty"`
+	Patroni         `json:"patroni,omitempty"`
+	Resources       `json:"resources,omitempty"`
 
 	TeamID              string   `json:"teamId"`
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
@@ -98,7 +98,7 @@ type PostgresSpec struct {
 	NumberOfInstances   int32                `json:"numberOfInstances"`
 	Users               map[string]userFlags `json:"users"`
 	MaintenanceWindows  []MaintenanceWindow  `json:"maintenanceWindows,omitempty"`
-	Clone 				CloneDescription 	 `json:"clone"`
+	Clone               CloneDescription     `json:"clone"`
 	ClusterName         string               `json:"-"`
 }
 

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -51,6 +51,12 @@ type Patroni struct {
 	MaximumLagOnFailover float32           `json:"maximum_lag_on_failover"` // float32 because https://github.com/kubernetes/kubernetes/issues/30213
 }
 
+// CloneDescription describes which cluster the new should clone and up to which point in time
+type CloneDescription struct {
+	ClusterName  string `json:"cluster"`
+	EndTimestamp string `json:"timestamp"`
+}
+
 type userFlags []string
 
 // PostgresStatus contains status of the PostgreSQL cluster (running, creation failed etc.)
@@ -79,14 +85,15 @@ type Postgresql struct {
 
 // PostgresSpec defines the specification for the PostgreSQL TPR.
 type PostgresSpec struct {
-	PostgresqlParam `json:"postgresql"`
-	Volume          `json:"volume,omitempty"`
-	Patroni         `json:"patroni,omitempty"`
-	Resources       `json:"resources,omitempty"`
+	PostgresqlParam  `json:"postgresql"`
+	Volume           `json:"volume,omitempty"`
+	Patroni          `json:"patroni,omitempty"`
+	Resources        `json:"resources,omitempty"`
+	CloneDescription `json:"clone,omitempty"`
 
 	TeamID              string   `json:"teamId"`
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
-	// EnableLoadBalancer  is a pointer, since it is importat to know if that parameters is omitted from the manifest
+	// EnableLoadBalancer  is a pointer, since it is important to know if that parameters is omitted from the manifest
 	UseLoadBalancer     *bool                `json:"useLoadBalancer,omitempty"`
 	ReplicaLoadBalancer bool                 `json:"replicaLoadBalancer,omitempty"`
 	NumberOfInstances   int32                `json:"numberOfInstances"`

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -247,7 +247,9 @@ func (p *Postgresql) UnmarshalJSON(data []byte) error {
 	if tmp2.Spec.Clone.ClusterName != "" {
 		_, err := extractClusterName(tmp2.Spec.Clone.ClusterName, tmp2.Spec.TeamID)
 		if err != nil {
-			tmp2.Error = fmt.Errorf(" %s for the cluster to clone", err)
+			tmp2.Error = fmt.Errorf("%s for the cluster to clone", err)
+			tmp2.Spec.Clone = CloneDescription{}
+			tmp2.Status = ClusterStatusInvalid
 		}
 	}
 	*p = tmp2

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -247,7 +247,7 @@ func (p *Postgresql) UnmarshalJSON(data []byte) error {
 	if tmp2.Spec.Clone.ClusterName != "" {
 		_, err := extractClusterName(tmp2.Spec.Clone.ClusterName, tmp2.Spec.TeamID)
 		if err != nil {
-			tmp2.Error = fmt.Errorf(" %s for the cluster to clone")
+			tmp2.Error = fmt.Errorf(" %s for the cluster to clone", err)
 		}
 	}
 	*p = tmp2

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -53,8 +53,8 @@ type Patroni struct {
 
 // CloneDescription describes which cluster the new should clone and up to which point in time
 type CloneDescription struct {
-	ClusterName  string `json:"cluster"`
-	EndTimestamp string `json:"timestamp"`
+	ClusterName  string `json:"cluster,omitempty"`
+	EndTimestamp string `json:"timestamp,omitempty"`
 }
 
 type userFlags []string
@@ -89,7 +89,7 @@ type PostgresSpec struct {
 	Volume           `json:"volume,omitempty"`
 	Patroni          `json:"patroni,omitempty"`
 	Resources        `json:"resources,omitempty"`
-	CloneDescription `json:"clone,omitempty"`
+	CloneDescription `json:"clone"`
 
 	TeamID              string   `json:"teamId"`
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -89,7 +89,6 @@ type PostgresSpec struct {
 	Volume           `json:"volume,omitempty"`
 	Patroni          `json:"patroni,omitempty"`
 	Resources        `json:"resources,omitempty"`
-	CloneDescription `json:"clone"`
 
 	TeamID              string   `json:"teamId"`
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
@@ -99,6 +98,7 @@ type PostgresSpec struct {
 	NumberOfInstances   int32                `json:"numberOfInstances"`
 	Users               map[string]userFlags `json:"users"`
 	MaintenanceWindows  []MaintenanceWindow  `json:"maintenanceWindows,omitempty"`
+	Clone 				CloneDescription 	 `json:"clone"`
 	ClusterName         string               `json:"-"`
 }
 

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -119,7 +119,7 @@ var unmarshalCluster = []struct {
 			Field:  "teamId",
 		},
 	},
-	[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"clone":{},"teamId":"","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`), nil},
+	[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`), nil},
 	{[]byte(`{
   "kind": "Postgresql",
   "apiVersion": "acid.zalan.do/v1",
@@ -222,9 +222,6 @@ var unmarshalCluster = []struct {
 					ResourceRequest: ResourceDescription{CPU: "10m", Memory: "50Mi"},
 					ResourceLimits:  ResourceDescription{CPU: "300m", Memory: "3000Mi"},
 				},
-				CloneDescription: CloneDescription{
-					ClusterName: "batman",
-				},
 
 				TeamID:              "ACID",
 				AllowedSourceRanges: []string{"127.0.0.1/32"},
@@ -248,11 +245,14 @@ var unmarshalCluster = []struct {
 						EndTime:   mustParseTime("05:15"),
 					},
 				},
+				Clone: CloneDescription{
+					ClusterName: "batman",
+				},
 				ClusterName: "testcluster1",
 			},
 			Error: nil,
 		},
-		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"clone":{"cluster":"batman"},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"]}}`), nil},
+		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"batman"}}}`), nil},
 	{
 		[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1","metadata": {"name": "teapot-testcluster1"}, "spec": {"teamId": "acid"}}`),
 		Postgresql{
@@ -267,12 +267,12 @@ var unmarshalCluster = []struct {
 			Status: ClusterStatusInvalid,
 			Error:  errors.New("name must match {TEAM}-{NAME} format"),
 		},
-		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"clone":{},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`), nil},
+		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`), nil},
 	{[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1"`),
 		Postgresql{},
 		[]byte{},
 		errors.New("unexpected end of JSON input")},
-	{[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster","creationTimestamp":qaz},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"clone":{},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`),
+	{[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster","creationTimestamp":qaz},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`),
 		Postgresql{},
 		[]byte{},
 		errors.New("invalid character 'q' looking for beginning of value")}}

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -161,7 +161,7 @@ var unmarshalCluster = []struct {
       }
     },
     "clone" : {
-     "cluster": "batman"
+     "cluster": "acid-batman"
      },
     "patroni": {
       "initdb": {
@@ -246,13 +246,13 @@ var unmarshalCluster = []struct {
 					},
 				},
 				Clone: CloneDescription{
-					ClusterName: "batman",
+					ClusterName: "acid-batman",
 				},
 				ClusterName: "testcluster1",
 			},
 			Error: nil,
 		},
-		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"batman"}}}`), nil},
+		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"}}}`), nil},
 	{
 		[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1","metadata": {"name": "teapot-testcluster1"}, "spec": {"teamId": "acid"}}`),
 		Postgresql{

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -119,7 +119,7 @@ var unmarshalCluster = []struct {
 			Field:  "teamId",
 		},
 	},
-	[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`), nil},
+	[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"clone":{},"teamId":"","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`), nil},
 	{[]byte(`{
   "kind": "Postgresql",
   "apiVersion": "acid.zalan.do/v1",
@@ -160,6 +160,9 @@ var unmarshalCluster = []struct {
         "memory": "3000Mi"
       }
     },
+    "clone" : {
+     "cluster": "batman"
+     },
     "patroni": {
       "initdb": {
         "encoding": "UTF8",
@@ -219,6 +222,10 @@ var unmarshalCluster = []struct {
 					ResourceRequest: ResourceDescription{CPU: "10m", Memory: "50Mi"},
 					ResourceLimits:  ResourceDescription{CPU: "300m", Memory: "3000Mi"},
 				},
+				CloneDescription: CloneDescription{
+					ClusterName: "batman",
+				},
+
 				TeamID:              "ACID",
 				AllowedSourceRanges: []string{"127.0.0.1/32"},
 				NumberOfInstances:   2,
@@ -245,7 +252,7 @@ var unmarshalCluster = []struct {
 			},
 			Error: nil,
 		},
-		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"]}}`), nil},
+		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"clone":{"cluster":"batman"},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"]}}`), nil},
 	{
 		[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1","metadata": {"name": "teapot-testcluster1"}, "spec": {"teamId": "acid"}}`),
 		Postgresql{
@@ -260,12 +267,12 @@ var unmarshalCluster = []struct {
 			Status: ClusterStatusInvalid,
 			Error:  errors.New("name must match {TEAM}-{NAME} format"),
 		},
-		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`), nil},
+		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"clone":{},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`), nil},
 	{[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1"`),
 		Postgresql{},
 		[]byte{},
 		errors.New("unexpected end of JSON input")},
-	{[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster","creationTimestamp":qaz},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`),
+	{[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster","creationTimestamp":qaz},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"clone":{},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null},"status":"Invalid"}`),
 		Postgresql{},
 		[]byte{},
 		errors.New("invalid character 'q' looking for beginning of value")}}

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -278,9 +278,9 @@ var unmarshalCluster = []struct {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "acid-testcluster1",
 			},
-			Spec:   PostgresSpec{
-				TeamID: "acid",
-				Clone: CloneDescription{},
+			Spec: PostgresSpec{
+				TeamID:      "acid",
+				Clone:       CloneDescription{},
 				ClusterName: "testcluster1",
 			},
 			Status: ClusterStatusInvalid,

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -268,6 +268,25 @@ var unmarshalCluster = []struct {
 			Error:  errors.New("name must match {TEAM}-{NAME} format"),
 		},
 		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`), nil},
+	{
+		in: []byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1","metadata": {"name": "acid-testcluster1"}, "spec": {"teamId": "acid", "clone": {"cluster": "team-batman"}}}`),
+		out: Postgresql{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Postgresql",
+				APIVersion: "acid.zalan.do/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "acid-testcluster1",
+			},
+			Spec:   PostgresSpec{
+				TeamID: "acid",
+				Clone: CloneDescription{},
+				ClusterName: "testcluster1",
+			},
+			Status: ClusterStatusInvalid,
+			Error:  errors.New("name must match {TEAM}-{NAME} format for the cluster to clone"),
+		},
+		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`), err: nil},
 	{[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1"`),
 		Postgresql{},
 		[]byte{},

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -38,7 +38,7 @@ type Auth struct {
 	OAuthTokenSecretName          spec.NamespacedName `name:"oauth_token_secret_name" default:"postgresql-operator"`
 	InfrastructureRolesSecretName spec.NamespacedName `name:"infrastructure_roles_secret_name"`
 	SuperUsername                 string              `name:"super_username" default:"postgres"`
-	ReplicationUsername           string              `name:"replication_username" default:"replication"`
+	ReplicationUsername           string              `name:"replication_username" default:"standby"`
 }
 
 // Config describes operator config

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -32,7 +32,7 @@ type Resources struct {
 
 // Auth describes authentication specific configuration parameters
 type Auth struct {
-	PamRoleName                   string              `name:"pam_rol_name" default:"zalandos"`
+	PamRoleName                   string              `name:"pam_role_name" default:"zalandos"`
 	PamConfiguration              string              `name:"pam_configuration" default:"https://info.example.com/oauth2/tokeninfo?access_token= uid realm=/employees"`
 	TeamsAPIUrl                   string              `name:"teams_api_url" default:"https://teams.example.com/api/"`
 	OAuthTokenSecretName          spec.NamespacedName `name:"oauth_token_secret_name" default:"postgresql-operator"`


### PR DESCRIPTION
The changes add a new JSON node `clone` with possible values `cluster`
and `timestamp`. `cluster` is mandatory, and setting a non-empty
`timestamp` triggers wal-e point in time recovery. Spilo and Patroni do
the whole heavy-lifting, the operator just defines certain variables and
gathers some data about how to connect to the host to clone or the
target S3 bucket.