### PR TITLE
Add missing return

### DIFF
--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -68,6 +68,8 @@ func (c *Cluster) closeDbConn() (err error) {
 			c.logger.Errorf("could not close database connection: %v", err)
 		}
 		c.pgDb = nil
+
+		return nil
 	}
 	c.logger.Warning("attempted to close an empty db connection object")
 	return nil


### PR DESCRIPTION
that will fix "attempted to close an empty db connection object" warnings