### PR TITLE
 Fix division by zero when connecting to the DB.

### DIFF
--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -58,7 +58,7 @@ func (c *Cluster) initDbConn() error {
 	}
 
 	c.logger.Debug("new database connection")
-	err = retryutil.Retry(0, constants.PostgresConnectRetryTimeout,
+	err = retryutil.Retry(constants.PostgresConnectTimeout, constants.PostgresConnectRetryTimeout,
 		func() (bool, error) {
 			err := conn.Ping()
 			if err == nil {


### PR DESCRIPTION
Apparently the retry function's first parameter is the duration of
a single attempt and it cannot be zero.