### PR TITLE
Change spilo docker image to demospilo

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -10,7 +10,7 @@ data:
   db_hosted_zone: db.example.com
   debug_logging: "true"
   dns_name_format: '{cluster}.{team}.staging.{hostedzone}'
-  docker_image: registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4
+  docker_image: registry.opensource.zalan.do/acid/demospilo-10:1.3-p2
   etcd_host: etcd-client.default.svc.cluster.local:2379
   secret_name_template: '{username}.{cluster}.credentials.{tprkind}.{tprgroup}'
   infrastructure_roles_secret_name: postgresql-infrastructure-roles


### PR DESCRIPTION
Image size is slightly more than 24MB, it doesn't contain wal-e and not suitable for production, but it is very good for demo purposes.