### PR TITLE
Minor fixes around PDB (pod-distruption-budget) syncing:

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -536,13 +536,9 @@ func (c *Cluster) Update(newSpec *spec.Postgresql) error {
 		c.logger.Infof("volumes have been updated successfully")
 	}
 
-	newPDB := c.generatePodDisruptionBudget()
-	if match, reason := c.samePDBWith(newPDB); !match {
-		c.logPDBChanges(c.PodDisruptionBudget, newPDB, true, reason)
-		if err := c.updatePodDisruptionBudget(newPDB); err != nil {
-			c.setStatus(spec.ClusterStatusUpdateFailed)
-			return fmt.Errorf("could not update pod disruption budget: %v", err)
-		}
+	if err := c.syncPodDisruptionBudget(true); err != nil {
+		c.setStatus(spec.ClusterStatusUpdateFailed)
+		return fmt.Errorf("could not update pod disruption budget: %v", err)
 	}
 
 	c.setStatus(spec.ClusterStatusRunning)

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -69,7 +69,7 @@ func (c *Cluster) serviceName(role PostgresRole) string {
 }
 
 func (c *Cluster) podDisruptionBudgetName() string {
-	return c.OpConfig.PDBNameFormat.Format("cluster", c.Spec.ClusterName)
+	return c.OpConfig.PDBNameFormat.Format("cluster", c.Name)
 }
 
 func (c *Cluster) resourceRequirements(resources spec.Resources) (*v1.ResourceRequirements, error) {
@@ -605,6 +605,7 @@ func (c *Cluster) generatePodDisruptionBudget() *policybeta1.PodDisruptionBudget
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.podDisruptionBudgetName(),
 			Namespace: c.Namespace,
+			Labels:    c.labelsSet(),
 		},
 		Spec: policybeta1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,


### PR DESCRIPTION
- Call comparison function in the case of the sync as well as for update
- Include full cluster name in PDB name
- Assign cluster labels to the PDB object