### PR TITLE
Add node toleration config to PodSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,35 @@ We can use the generated secret of the `postgres` robot user to connect to our `
     $ psql -U postgres
 
 
+### Configuration Options
+
+The operator can be configured with the provided ConfigMap (`manifests/configmap.yaml`).
+
+#### Use Taints and Tolerations for Dedicated Postgres Nodes
+
+To ensure Postgres pods are running on nodes without any other application pods, you can use [taints and tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) and configure the required toleration in the operator ConfigMap.
+
+As an example you can set following node taint:
+
+```
+$ kubectl taint nodes <nodeName> postgres=:NoSchedule
+```
+
+And configure the toleration for the Postgres pods by adding following line to the ConfigMap:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-operator
+data:
+  toleration: "key:postgres,operator:Exists,effect:NoSchedule"
+  ...
+```
+
+Please be ware that the taint and toleration only ensures that no other pod gets scheduled to the "postgres" node but not that Postgres pods are placed on such a node. This can be achieved by setting a node affinity rule in the ConfigMap.
+
+
 # Setup development environment
 
 The following steps guide you through the setup to work on the operator itself.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ data:
   ...
 ```
 
+Or you can specify and/or overwrite the tolerations for each postgres instance in the postgres manifest:
+
+```
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: acid-minimal-cluster
+spec:
+  teamId: "ACID"
+  tolerations:
+  - key: postgres
+    operator: Exists
+    effect: NoSchedule
+```
+
 Please be ware that the taint and toleration only ensures that no other pod gets scheduled to the "postgres" node but not that Postgres pods are placed on such a node. This can be achieved by setting a node affinity rule in the ConfigMap.
 
 

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -7,6 +7,7 @@ data:
   cluster_labels: application:spilo
   cluster_name_label: version
   pod_role_label: spilo-role
+  toleration: "key:postgres,operator:Exists,effect:NoSchedule"
   db_hosted_zone: db.example.com
   debug_logging: "true"
   dns_name_format: '{cluster}.{team}.staging.{hostedzone}'

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -7,7 +7,6 @@ data:
   cluster_labels: application:spilo
   cluster_name_label: version
   pod_role_label: spilo-role
-  toleration: "key:postgres,operator:Exists,effect:NoSchedule"
   db_hosted_zone: db.example.com
   debug_logging: "true"
   dns_name_format: '{cluster}.{team}.staging.{hostedzone}'

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -250,6 +250,22 @@ func (c *Cluster) nodeAffinity() *v1.Affinity {
 	}
 }
 
+func (c *Cluster) tolerations() []v1.Toleration {
+	podToleration := c.Config.OpConfig.PodToleration
+	if (len(podToleration["key"]) > 0 || len(podToleration["operator"]) > 0 || len(podToleration["value"]) > 0 || len(podToleration["effect"]) > 0) {
+		return []v1.Toleration{
+			{
+				Key:      podToleration["key"],
+				Operator: v1.TolerationOperator(podToleration["operator"]),
+				Value:    podToleration["value"],
+				Effect:   v1.TaintEffect(podToleration["effect"]),
+			},
+		}
+	} else {
+		return []v1.Toleration{}
+	}
+}
+
 func (c *Cluster) generatePodTemplate(resourceRequirements *v1.ResourceRequirements,
 	pgParameters *spec.PostgresqlParam,
 	patroniParameters *spec.Patroni,
@@ -372,6 +388,7 @@ func (c *Cluster) generatePodTemplate(resourceRequirements *v1.ResourceRequireme
 		TerminationGracePeriodSeconds: &terminateGracePeriodSeconds,
 		Containers:                    []v1.Container{container},
 		Affinity:                      c.nodeAffinity(),
+		Tolerations:                   c.tolerations(),
 	}
 
 	template := v1.PodTemplateSpec{

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // MaintenanceWindow describes the time window when the operator is allowed to do maintenance on a cluster.
@@ -102,6 +103,7 @@ type PostgresSpec struct {
 	Clone               CloneDescription     `json:"clone"`
 	ClusterName         string               `json:"-"`
 	Databases           map[string]string    `json:"databases,omitempty"`
+	Tolerations         []v1.Toleration      `json:"tolerations,omitempty"`
 }
 
 // PostgresqlList defines a list of PostgreSQL clusters.

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -25,6 +25,7 @@ type Resources struct {
 	ClusterLabels           map[string]string `name:"cluster_labels" default:"application:spilo"`
 	ClusterNameLabel        string            `name:"cluster_name_label" default:"cluster-name"`
 	PodRoleLabel            string            `name:"pod_role_label" default:"spilo-role"`
+	PodToleration          	map[string]string `name:"toleration" default:""`
 	DefaultCPURequest       string            `name:"default_cpu_request" default:"100m"`
 	DefaultMemoryRequest    string            `name:"default_memory_request" default:"100Mi"`
 	DefaultCPULimit         string            `name:"default_cpu_limit" default:"3"`


### PR DESCRIPTION
Our goal is to provide "dedicated" Kubernetes nodes for Postgres instances and this PR introduces a config option to set a node toleration on the Postgres pods.

The configmap is extended with the option `toleration` which allows configuration of a Kubernetes toleration to match node taints. These nodes are then reserved for Postgres pods and don't get any other pods scheduled except the toleration is added.

If the `toleration` option is not configured, no toleration specs are added to the StatefulSet. If a toleration is defined like:

```
toleration: "key:postgres,operator:Exists,effect:NoSchedule"
```

following specification is added to the StatefulSet:

```
tolerations:
- effect: NoSchedule
  key: postgres
  operator: Exists
```
