### PR TITLE
Custom Environment Variables for Postgres Pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,38 @@ spec:
 
 Please be ware that the taint and toleration only ensures that no other pod gets scheduled to the "postgres" node but not that Postgres pods are placed on such a node. This can be achieved by setting a node affinity rule in the ConfigMap.
 
+#### Custom Pod Environment Variables
+
+It is possible to configure a config map which is used by the Postgres pods as an additional provider for environment variables.
+
+One use case is to customize the Spilo image and configure it with environment variables. The config map with the additional settings is configured in the operator's main config map:
+
+**postgres-operator ConfigMap**
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-operator
+data:
+  # referencing config map with custom settings
+  pod_environment_configmap: postgres-pod-config
+  ...
+```
+
+**referenced ConfigMap `postgres-pod-config`**
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-pod-config
+  namespace: default
+data:
+  MY_CUSTOM_VAR: value
+```
+
+This ConfigMap is then added as a source of environment variables to the Postgres StatefulSet/pods.
 
 # Setup development environment
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -368,6 +368,10 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *comp
 		needsRollUpdate = true
 		reasons = append(reasons, "new statefulset's container environment doesn't match the current one")
 	}
+	if !reflect.DeepEqual(container1.EnvFrom, container2.EnvFrom) {
+		needsRollUpdate = true
+		reasons = append(reasons, "new statefulset's container environment sources don't match the current one")
+	}
 
 	if needsRollUpdate || needsReplace {
 		match = false

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -361,6 +361,13 @@ func (c *Cluster) generatePodTemplate(resourceRequirements *v1.ResourceRequireme
 	if cloneDescription.ClusterName != "" {
 		envVars = append(envVars, c.generateCloneEnvironment(cloneDescription)...)
 	}
+
+	envFromSource := []v1.EnvFromSource{}
+	if c.OpConfig.PodEnvironmentConfigMap != "" {
+		configMapRef := v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: c.OpConfig.PodEnvironmentConfigMap}}
+		envFromSource = append(envFromSource, v1.EnvFromSource{ConfigMapRef: &configMapRef})
+	}
+
 	privilegedMode := true
 	container := v1.Container{
 		Name:            c.containerName(),
@@ -388,6 +395,7 @@ func (c *Cluster) generatePodTemplate(resourceRequirements *v1.ResourceRequireme
 			},
 		},
 		Env: envVars,
+		EnvFrom: envFromSource,
 		SecurityContext: &v1.SecurityContext{
 			Privileged: &privilegedMode,
 		},

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -31,6 +31,7 @@ type Resources struct {
 	DefaultCPULimit         string            `name:"default_cpu_limit" default:"3"`
 	DefaultMemoryLimit      string            `name:"default_memory_limit" default:"1Gi"`
 	EOLNodeLabel            map[string]string `name:"eol_node_label" default:"eol:true"`
+	PodEnvironmentConfigMap string            `name:"pod_environment_configmap" default:""`
 }
 
 // Auth describes authentication specific configuration parameters


### PR DESCRIPTION
This PR adds the ability to configure a config map which is used by the Postgres pods as additional provider for environment variables. This allows to customize the Spilo image and configure it with environment variables. The config map with the additional settings is configured in the operator's main config map.

**postgres-operator ConfigMap**

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: postgres-operator
data:
  # referencing config map with custom settings
  pod_env_configmap: postgres-pod-config
  ...
```

**ConfigMap for custom settings**

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: postgres-pod-config
  namespace: default
data:
  MY_CUSTOM_VAR: value
  FOR_POSTGRES: demo
```


This ConfigMap is then added to the StatefulSet/pods with following spec:

```
envFrom:
- configMapRef:
    name: postgres-pod-config
```

## Considerations

In our case we changed some scripts in the Spilo image to have a custom backup solution which needs to be configured with additional environment variables. I don't think we can contribute the Spilo changes back as they are very specific for our use cause. Therefore it doesn't make sense to add additional environment settings to the operator ConfigMap and have an explicit mapping in the operator code. And I think having the additional ConfigMap results in a very simple and generic way to allow custom variables.

What do you think? Is it useful for other use cases or against the operator paradigm in general?

Please let me know.






If the setting is omitted in the operator config, nothing is added to the pod.