### PR TITLE
Avoid overwriting infrastructure roles.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -629,7 +629,7 @@ func (c *Cluster) initRobotUsers() error {
 			// avoid overwriting the password if the user is already there. The flags should be
 			// merged here, but since there is no mechanism to define them for non-robot roles
 			// they are assigned from the robot user.
-			c.logger.Debugf("merging user %q data", username)
+			c.logger.Debugf("merging manifest and infrastructure user %q data", username)
 			user := c.pgUsers[username]
 			user.Flags = flags
 			c.pgUsers[username] = user

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -654,7 +654,7 @@ func (c *Cluster) initHumanUsers() error {
 		}
 
 		if _, present := c.pgUsers[username]; present {
-			c.logger.Warnf("overwriting existing user %q with the data from the teams API")
+			c.logger.Warnf("overwriting existing user %q with the data from the teams API", username)
 		}
 
 		c.pgUsers[username] = spec.PgUser{

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -610,12 +610,12 @@ func (c *Cluster) initSystemUsers() {
 func (c *Cluster) initRobotUsers() error {
 	for username, userFlags := range c.Spec.Users {
 		if !isValidUsername(username) {
-			return fmt.Errorf("invalid username: '%v'", username)
+			return fmt.Errorf("invalid username: %q", username)
 		}
 
 		flags, err := normalizeUserFlags(userFlags)
 		if err != nil {
-			return fmt.Errorf("invalid flags for user '%v': %v", username, err)
+			return fmt.Errorf("invalid flags for user %q: %v", username, err)
 		}
 		if _, present := c.pgUsers[username]; !present {
 			c.pgUsers[username] = spec.PgUser{
@@ -630,6 +630,7 @@ func (c *Cluster) initRobotUsers() error {
 			c.logger.Debugf("merging user %q data", username)
 			user := c.pgUsers[username]
 			user.Flags = flags
+			c.pgUsers[username] = user
 		}
 	}
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,125 @@
+package cluster
+
+import (
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"github.com/zalando-incubator/postgres-operator/pkg/spec"
+	"github.com/zalando-incubator/postgres-operator/pkg/util/k8sutil"
+	"github.com/zalando-incubator/postgres-operator/pkg/util/teams"
+	"reflect"
+	"testing"
+)
+
+var logger = logrus.New().WithField("test", "cluster")
+var cl = New(Config{}, k8sutil.KubernetesClient{}, spec.Postgresql{}, logger)
+
+func TestInitRobotUsers(t *testing.T) {
+	testName := "TestInitRobotUsers"
+	tests := []struct {
+		manifestUsers map[string]spec.UserFlags
+		infraRoles    map[string]spec.PgUser
+		result        map[string]spec.PgUser
+		err           error
+	}{
+		{
+			manifestUsers: map[string]spec.UserFlags{"foo": {"superuser", "createdb"}},
+			infraRoles:    map[string]spec.PgUser{"foo": {Name: "foo", Password: "bar"}},
+			result: map[string]spec.PgUser{"foo": {Name: "foo", Password: "bar",
+				Flags: []string{"CREATEDB", "LOGIN", "SUPERUSER"}}},
+			err: nil,
+		},
+		{
+			manifestUsers: map[string]spec.UserFlags{"!fooBar": {"superuser", "createdb"}},
+			err:           fmt.Errorf(`invalid username: "!fooBar"`),
+		},
+		{
+			manifestUsers: map[string]spec.UserFlags{"foobar": {"!superuser", "createdb"}},
+			err: fmt.Errorf(`invalid flags for user "foobar": ` +
+				`user flag "!superuser" is not alphanumeric`),
+		},
+		{
+			manifestUsers: map[string]spec.UserFlags{"foobar": {"superuser1", "createdb"}},
+			err: fmt.Errorf(`invalid flags for user "foobar": ` +
+				`user flag "SUPERUSER1" is not valid`),
+		},
+		{
+			manifestUsers: map[string]spec.UserFlags{"foobar": {"inherit", "noinherit"}},
+			err: fmt.Errorf(`invalid flags for user "foobar": ` +
+				`conflicting user flags: "NOINHERIT" and "INHERIT"`),
+		},
+	}
+	for _, tt := range tests {
+		cl.Spec.Users = tt.manifestUsers
+		cl.pgUsers = tt.infraRoles
+		if err := cl.initRobotUsers(); err != nil {
+			if tt.err == nil {
+				t.Errorf("%s got an unexpected error: %v", testName, err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Errorf("%s expected error %v, got %v", testName, tt.err, err)
+			}
+		} else {
+			if !reflect.DeepEqual(cl.pgUsers, tt.result) {
+				t.Errorf("%s expected: %#v, got %#v", testName, tt.result, cl.pgUsers)
+			}
+		}
+	}
+}
+
+type mockOAuthTokenGetter struct {
+}
+
+func (m *mockOAuthTokenGetter) getOAuthToken() (string, error) {
+	return "", nil
+}
+
+type mockTeamsAPIClient struct {
+	members []string
+}
+
+func (m *mockTeamsAPIClient) TeamInfo(teamID, token string) (tm *teams.Team, err error) {
+	return &teams.Team{Members: m.members}, nil
+}
+
+func (m *mockTeamsAPIClient) setMembers(members []string) {
+	m.members = members
+}
+
+func TestInitHumanUsers(t *testing.T) {
+
+	var mockTeamsAPI mockTeamsAPIClient
+	cl.oauthTokenGetter = &mockOAuthTokenGetter{}
+	cl.teamsAPIClient = &mockTeamsAPI
+	testName := "TestInitHumanUsers"
+
+	cl.OpConfig.EnableTeamSuperuser = true
+	cl.OpConfig.EnableTeamsAPI = true
+	cl.OpConfig.PamRoleName = "zalandos"
+	cl.Spec.TeamID = "test"
+
+	tests := []struct {
+		existingRoles map[string]spec.PgUser
+		teamRoles     []string
+		result        map[string]spec.PgUser
+	}{
+		{
+			existingRoles: map[string]spec.PgUser{"foo": {Name: "foo", Flags: []string{"NOLOGIN"}},
+				"bar": {Name: "bar", Flags: []string{"NOLOGIN"}}},
+			teamRoles: []string{"foo"},
+			result: map[string]spec.PgUser{"foo": {Name: "foo", MemberOf: []string{cl.OpConfig.PamRoleName}, Flags: []string{"LOGIN", "SUPERUSER"}},
+				"bar": {Name: "bar", Flags: []string{"NOLOGIN"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		cl.pgUsers = tt.existingRoles
+		mockTeamsAPI.setMembers(tt.teamRoles)
+		if err := cl.initHumanUsers(); err != nil {
+			t.Errorf("%s got an unexpected error %v", testName, err)
+		}
+
+		if !reflect.DeepEqual(cl.pgUsers, tt.result) {
+			t.Errorf("%s expects %#v, got %#v", testName, tt.result, cl.pgUsers)
+		}
+	}
+}

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zalando-incubator/postgres-operator/pkg/util"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/constants"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/retryutil"
+	"sort"
 )
 
 func isValidUsername(username string) bool {
@@ -77,7 +78,7 @@ func normalizeUserFlags(userFlags []string) ([]string, error) {
 	if addLogin {
 		flags = append(flags, constants.RoleFlagLogin)
 	}
-
+	sort.Strings(flags)
 	return flags, nil
 }
 

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -58,7 +58,7 @@ type CloneDescription struct {
 	EndTimestamp string `json:"timestamp,omitempty"`
 }
 
-type userFlags []string
+type UserFlags []string
 
 // PostgresStatus contains status of the PostgreSQL cluster (running, creation failed etc.)
 type PostgresStatus string
@@ -99,7 +99,7 @@ type PostgresSpec struct {
 	UseLoadBalancer     *bool                `json:"useLoadBalancer,omitempty"`
 	ReplicaLoadBalancer bool                 `json:"replicaLoadBalancer,omitempty"`
 	NumberOfInstances   int32                `json:"numberOfInstances"`
-	Users               map[string]userFlags `json:"users"`
+	Users               map[string]UserFlags `json:"users"`
 	MaintenanceWindows  []MaintenanceWindow  `json:"maintenanceWindows,omitempty"`
 	Clone               CloneDescription     `json:"clone"`
 	ClusterName         string               `json:"-"`

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -226,7 +226,7 @@ var unmarshalCluster = []struct {
 				TeamID:              "ACID",
 				AllowedSourceRanges: []string{"127.0.0.1/32"},
 				NumberOfInstances:   2,
-				Users:               map[string]userFlags{"zalando": {"superuser", "createdb"}},
+				Users:               map[string]UserFlags{"zalando": {"superuser", "createdb"}},
 				MaintenanceWindows: []MaintenanceWindow{{
 					Everyday:  false,
 					Weekday:   time.Monday,

--- a/pkg/util/teams/teams.go
+++ b/pkg/util/teams/teams.go
@@ -43,6 +43,10 @@ type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+type Interface interface {
+	TeamInfo(teamID, token string) (tm *Team, err error)
+}
+
 // API describes teams API
 type API struct {
 	httpClient


### PR DESCRIPTION
For a role defined in both the infrastructure roles secret and the cluster manifest use the infrastructure role definition and add flags defined in the manifest. #166 