### PR TITLE
Avoid overwriting critical users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ The following steps will get you the docker image built and deployed.
 of configuration parameters applied to the roles fetched from the API.
 For instance, `team_api_role_configuration: log_statement:all,search_path:'public,"$user"'`.
 By default is set to *"log_statement:all"*. See [PostgreSQL documentation on ALTER ROLE .. SET](https://www.postgresql.org/docs/current/static/sql-alterrole.html) for to learn about the available options.
+* protected_role_names - a list of role names that should be forbidden as the manifest, infrastructure and teams API roles.
+The default value is `admin`. Operator will also disallow superuser and replication roles to be redefined.
 
 
 ### Debugging the operator itself

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -615,6 +615,9 @@ func (c *Cluster) initRobotUsers() error {
 			return fmt.Errorf("invalid username: %q", username)
 		}
 
+		if c.avoidProtectedOrSystemRole(username, "manifest robot role") {
+			continue
+		}
 		flags, err := normalizeUserFlags(userFlags)
 		if err != nil {
 			return fmt.Errorf("invalid flags for user %q: %v", username, err)
@@ -648,6 +651,9 @@ func (c *Cluster) initHumanUsers() error {
 		flags := []string{constants.RoleFlagLogin}
 		memberOf := []string{c.OpConfig.PamRoleName}
 
+		if c.avoidProtectedOrSystemRole(username, "API role") {
+			continue
+		}
 		if c.OpConfig.EnableTeamSuperuser {
 			flags = append(flags, constants.RoleFlagSuperuser)
 		} else {
@@ -677,6 +683,9 @@ func (c *Cluster) initInfrastructureRoles() error {
 		if !isValidUsername(username) {
 			return fmt.Errorf("invalid username: '%v'", username)
 		}
+		if c.avoidProtectedOrSystemRole(username, "infrastructure role") {
+			continue
+		}
 		flags, err := normalizeUserFlags(data.Flags)
 		if err != nil {
 			return fmt.Errorf("invalid flags for user '%v': %v", username, err)
@@ -685,6 +694,18 @@ func (c *Cluster) initInfrastructureRoles() error {
 		c.pgUsers[username] = data
 	}
 	return nil
+}
+
+func (c *Cluster) avoidProtectedOrSystemRole(username, purpose string) bool {
+	if c.isProtectedUsername(username) {
+		c.logger.Warnf("cannot initialize a new %s with the name of the protected user %q", purpose, username)
+		return true
+	}
+	if c.isSystemUsername(username) {
+		c.logger.Warnf("cannot initialize a new %s with the name of the system user %q", purpose, username)
+		return true
+	}
+	return false
 }
 
 // GetCurrentProcess provides name of the last process of the cluster

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -168,6 +168,11 @@ func (c *Cluster) setStatus(status spec.PostgresStatus) {
 // initUsers populates c.systemUsers and c.pgUsers maps.
 func (c *Cluster) initUsers() error {
 	c.setProcessName("initializing users")
+
+	// clear our the previous state of the cluster users (in case we are running a sync).
+	c.systemUsers = map[string]spec.PgUser{}
+	c.pgUsers = map[string]spec.PgUser{}
+
 	c.initSystemUsers()
 
 	if err := c.initInfrastructureRoles(); err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -620,7 +620,7 @@ func (c *Cluster) initRobotUsers() error {
 			return fmt.Errorf("invalid username: %q", username)
 		}
 
-		if c.avoidProtectedOrSystemRole(username, "manifest robot role") {
+		if c.shouldAvoidProtectedOrSystemRole(username, "manifest robot role") {
 			continue
 		}
 		flags, err := normalizeUserFlags(userFlags)
@@ -656,7 +656,7 @@ func (c *Cluster) initHumanUsers() error {
 		flags := []string{constants.RoleFlagLogin}
 		memberOf := []string{c.OpConfig.PamRoleName}
 
-		if c.avoidProtectedOrSystemRole(username, "API role") {
+		if c.shouldAvoidProtectedOrSystemRole(username, "API role") {
 			continue
 		}
 		if c.OpConfig.EnableTeamSuperuser {
@@ -688,7 +688,7 @@ func (c *Cluster) initInfrastructureRoles() error {
 		if !isValidUsername(username) {
 			return fmt.Errorf("invalid username: '%v'", username)
 		}
-		if c.avoidProtectedOrSystemRole(username, "infrastructure role") {
+		if c.shouldAvoidProtectedOrSystemRole(username, "infrastructure role") {
 			continue
 		}
 		flags, err := normalizeUserFlags(data.Flags)
@@ -701,7 +701,7 @@ func (c *Cluster) initInfrastructureRoles() error {
 	return nil
 }
 
-func (c *Cluster) avoidProtectedOrSystemRole(username, purpose string) bool {
+func (c *Cluster) shouldAvoidProtectedOrSystemRole(username, purpose string) bool {
 	if c.isProtectedUsername(username) {
 		c.logger.Warnf("cannot initialize a new %s with the name of the protected user %q", purpose, username)
 		return true

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -60,6 +60,19 @@ func isValidUsername(username string) bool {
 	return userRegexp.MatchString(username)
 }
 
+func (c *Cluster) isProtectedUsername(username string) bool {
+	for _, protected := range c.OpConfig.ProtectedRoles {
+		if username == protected {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Cluster) isSystemUsername(username string) bool {
+	return (username == c.OpConfig.SuperUsername || username == c.OpConfig.ReplicationUsername)
+}
+
 func isValidFlag(flag string) bool {
 	for _, validFlag := range []string{constants.RoleFlagSuperuser, constants.RoleFlagLogin, constants.RoleFlagCreateDB,
 		constants.RoleFlagInherit, constants.RoleFlagReplication, constants.RoleFlagByPassRLS} {

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	ClusterHistoryEntries    int               `name:"cluster_history_entries" default:"1000"`
 	TeamAPIRoleConfiguration map[string]string `name:"team_api_role_configuration" default:"log_statement:all"`
 	PodTerminateGracePeriod  time.Duration     `name:"pod_terminate_grace_period" default:"5m"`
+	ProtectedRoles           []string          `name:"protected_role_names" default:"admin"`
 }
 
 // MustMarshal marshals the config or panics


### PR DESCRIPTION
Disallow defining new users either in the cluster manifest, teams
API or infrastructure roles with the names mentioned in the new
protected_role_names parameter (it is a list).

Additionally, forbid defining a user with the name matching either
super_username or replication_username, so that we don't overwrite
system roles required for correct working of the operator itself.