### PR TITLE
Fixes for the case of re-creating the cluster after deletion.

### DIFF
--- a/pkg/cluster/pg.go
+++ b/pkg/cluster/pg.go
@@ -191,7 +191,7 @@ func (c *Cluster) executeCreateDatabase(datname, owner string) error {
 	}
 	c.logger.Infof("creating database %q with owner %q", datname, owner)
 
-	if _, err := c.pgDb.Query(fmt.Sprintf(createDatabaseSQL, datname, owner)); err != nil {
+	if _, err := c.pgDb.Exec(fmt.Sprintf(createDatabaseSQL, datname, owner)); err != nil {
 		return fmt.Errorf("could not execute create database: %v", err)
 	}
 	return nil
@@ -204,7 +204,7 @@ func (c *Cluster) executeAlterDatabaseOwner(datname string, owner string) error 
 		return nil
 	}
 	c.logger.Infof("changing database %q owner to %q", datname, owner)
-	if _, err := c.pgDb.Query(fmt.Sprintf(alterDatabaseOwnerSQL, datname, owner)); err != nil {
+	if _, err := c.pgDb.Exec(fmt.Sprintf(alterDatabaseOwnerSQL, datname, owner)); err != nil {
 		return fmt.Errorf("could not execute alter database owner: %v", err)
 	}
 	return nil

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -473,7 +473,7 @@ func (c *Cluster) deleteSecret(secret *v1.Secret) error {
 
 func (c *Cluster) createRoles() (err error) {
 	// TODO: figure out what to do with duplicate names (humans and robots) among pgUsers
-	return c.syncRoles(false)
+	return c.syncRoles()
 }
 
 // GetServiceMaster returns cluster's kubernetes master Service

--- a/pkg/util/users/users.go
+++ b/pkg/util/users/users.go
@@ -95,7 +95,7 @@ func (s DefaultUserSyncStrategy) ExecuteSyncRequests(reqs []spec.PgSyncUserReque
 func (strategy DefaultUserSyncStrategy) alterPgUserSet(user spec.PgUser, db *sql.DB) (err error) {
 	queries := produceAlterRoleSetStmts(user)
 	query := fmt.Sprintf(doBlockStmt, strings.Join(queries, ";"))
-	if err = runQueryDiscardResult(db, query); err != nil {
+	if _, err = db.Exec(query); err != nil {
 		err = fmt.Errorf("dB error: %v, query: %s", err, query)
 		return
 	}
@@ -120,7 +120,7 @@ func (s DefaultUserSyncStrategy) createPgUser(user spec.PgUser, db *sql.DB) (err
 	}
 	query := fmt.Sprintf(createUserSQL, user.Name, strings.Join(userFlags, " "), userPassword)
 
-	err = runQueryDiscardResult(db, query) // TODO: Try several times
+	_, err = db.Exec(query) // TODO: Try several times
 	if err != nil {
 		err = fmt.Errorf("dB error: %v, query: %s", err, query)
 		return
@@ -146,7 +146,7 @@ func (s DefaultUserSyncStrategy) alterPgUser(user spec.PgUser, db *sql.DB) (err 
 
 	query := fmt.Sprintf(doBlockStmt, strings.Join(resultStmt, ";"))
 
-	err = runQueryDiscardResult(db, query) // TODO: Try several times
+	_, err = db.Exec(query) // TODO: Try several times
 	if err != nil {
 		err = fmt.Errorf("dB error: %v query %s", err, query)
 		return
@@ -214,12 +214,4 @@ func quoteParameterValue(name, val string) string {
 		return val
 	}
 	return fmt.Sprintf(`'%s'`, strings.Trim(val, " "))
-}
-
-func runQueryDiscardResult(db *sql.DB, sql string) error {
-	rows, err := db.Query(sql)
-	if rows != nil {
-		rows.Close()
-	}
-	return err
 }


### PR DESCRIPTION
- make sure that the secrets for the system users (superuser, replication)
  are not deleted when the main cluster is. Therefore, we can re-create
  the cluster, potentially forcing Patroni to restore it from the backup
  and enable Patroni to connect, since it will use the old password, not
  the newly generated random one.

- when syncing users, always check whether they are already in the DB.
  Previously, we did this only for the sync cluster case, but the new
  cluster could be actually the one restored from the backup by Patroni,
  having all or some of the users already in place.

 - delete endponts last. Patroni uses the $clustername endpoint in order
   to store the leader related metadata. If we remove it before removing
   all pods, one of those pods running Patroni will re-create it and the
   next attempt to create the cluster with the same name will stuble on
   the existing endpoint.

 - Use db.Exec instead of db.Query for queries that expect no result.
   This also fixes the issue with the DB creation, since we didn't
   release an empty Row object it was not possible to create more than
   one database for a cluster.