### PR TITLE
custom-env-rebased

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,38 @@ spec:
 Please be aware that the taint and toleration only ensures that no other pod gets scheduled to a PostgreSQL node 
 but not that PostgreSQL pods are placed on such a node. This can be achieved by setting a node affinity rule in the ConfigMap.
 
+#### Custom Pod Environment Variables
+
+It is possible to configure a config map which is used by the Postgres pods as an additional provider for environment variables.
+
+One use case is to customize the Spilo image and configure it with environment variables. The config map with the additional settings is configured in the operator's main config map:
+
+**postgres-operator ConfigMap**
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-operator
+data:
+  # referencing config map with custom settings
+  pod_environment_configmap: postgres-pod-config
+  ...
+```
+
+**referenced ConfigMap `postgres-pod-config`**
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-pod-config
+  namespace: default
+data:
+  MY_CUSTOM_VAR: value
+```
+
+This ConfigMap is then added as a source of environment variables to the Postgres StatefulSet/pods.
 
 # Setup development environment
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ data:
 
 This ConfigMap is then added as a source of environment variables to the Postgres StatefulSet/pods.
 
+:exclamation: Note that there are environment variables defined by the operator itself in order to pass parameters to the Spilo image. The values from the operator for those variables will take precedence over those defined in the `pod_environment_configmap`.
+
 # Setup development environment
 
 The following steps guide you through the setup to work on the operator itself.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -377,7 +377,7 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *comp
 	}
 	if !reflect.DeepEqual(container1.EnvFrom, container2.EnvFrom) {
 		needsRollUpdate = true
-		reasons = append(reasons, "new statefulset's container environment sources doesn't match the current one")
+		reasons = append(reasons, "new statefulset's container environment sources don't match the current one")
 	}
 
 	if needsRollUpdate || needsReplace {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -375,6 +375,10 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *comp
 		needsRollUpdate = true
 		reasons = append(reasons, "new statefulset's container environment doesn't match the current one")
 	}
+	if !reflect.DeepEqual(container1.EnvFrom, container2.EnvFrom) {
+		needsRollUpdate = true
+		reasons = append(reasons, "new statefulset's container environment sources doesn't match the current one")
+	}
 
 	if needsRollUpdate || needsReplace {
 		match = false

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -362,6 +362,13 @@ func (c *Cluster) generatePodTemplate(resourceRequirements *v1.ResourceRequireme
 	if cloneDescription.ClusterName != "" {
 		envVars = append(envVars, c.generateCloneEnvironment(cloneDescription)...)
 	}
+
+	envFromSource := []v1.EnvFromSource{}
+	if c.OpConfig.PodEnvironmentConfigMap != "" {
+		configMapRef := v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: c.OpConfig.PodEnvironmentConfigMap}}
+		envFromSource = append(envFromSource, v1.EnvFromSource{ConfigMapRef: &configMapRef})
+	}
+
 	privilegedMode := true
 	containerImage := c.OpConfig.DockerImage
 	if dockerImage != nil && *dockerImage != "" {
@@ -393,6 +400,7 @@ func (c *Cluster) generatePodTemplate(resourceRequirements *v1.ResourceRequireme
 			},
 		},
 		Env: envVars,
+		EnvFrom: envFromSource,
 		SecurityContext: &v1.SecurityContext{
 			Privileged: &privilegedMode,
 		},

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -30,6 +30,7 @@ type Resources struct {
 	DefaultMemoryRequest    string            `name:"default_memory_request" default:"100Mi"`
 	DefaultCPULimit         string            `name:"default_cpu_limit" default:"3"`
 	DefaultMemoryLimit      string            `name:"default_memory_limit" default:"1Gi"`
+	PodEnvironmentConfigMap string            `name:"pod_environment_configmap" default:""`
 	NodeEOLLabel            map[string]string `name:"node_eol_label" default:"lifecycle-status:pending-decommission"`
 	NodeReadinessLabel      map[string]string `name:"node_readiness_label" default:"lifecycle-status:ready"`
 }


### PR DESCRIPTION
Use a ConfigMap set by the operator configuration option `pod_environment_configmap` in order to supply arbitrary environment variables to Spilo.
On conflict between the options supplied by the operator and those listed in the pod environment ConfigMap the operator options win.

This is a rebase of https://github.com/zalando-incubator/postgres-operator/pull/152/ to the recent master to eliminate conflicts.
