### PR TITLE
Improve behavior on node decomissionining

### DIFF
--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -319,6 +319,6 @@ func (c *Cluster) podIsEndOfLife(pod *v1.Pod) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return node.Spec.Unschedulable || util.MapContains(node.Labels, c.OpConfig.NodeEOLLabel), nil
+	return node.Spec.Unschedulable || !util.MapContains(node.Labels, c.OpConfig.NodeReadinessLabel), nil
 
 }

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/zalando-incubator/postgres-operator/pkg/spec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+const (
+	readyLabel = "lifecycle-status"
+	readyValue = "ready"
+)
+
+func initializeController() *Controller {
+	var c = NewController(&spec.ControllerConfig{})
+	c.opConfig.NodeReadinessLabel = map[string]string{readyLabel: readyValue}
+	return c
+}
+
+func makeNode(labels map[string]string, isSchedulable bool) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: v1.NamespaceDefault,
+			Labels:    labels,
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: !isSchedulable,
+		},
+	}
+}
+
+var c = initializeController()
+
+func TestNodeIsReady(t *testing.T) {
+	testName := "TestNodeIsReady"
+	var testTable = []struct {
+		in  *v1.Node
+		out bool
+	}{
+		{
+			in:  makeNode(map[string]string{"foo": "bar"}, true),
+			out: true,
+		},
+		{
+			in:  makeNode(map[string]string{"foo": "bar"}, false),
+			out: false,
+		},
+		{
+			in:  makeNode(map[string]string{readyLabel: readyValue}, false),
+			out: true,
+		},
+		{
+			in:  makeNode(map[string]string{"foo": "bar", "master": "true"}, false),
+			out: true,
+		},
+	}
+	for _, tt := range testTable {
+		if isReady := c.nodeIsReady(tt.in); isReady != tt.out {
+			t.Errorf("%s: expected response %t doesn't match the actual %t for the node %#v",
+				testName, tt.out, isReady, tt.in)
+		}
+	}
+}

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -31,7 +31,6 @@ type Resources struct {
 	DefaultCPULimit         string            `name:"default_cpu_limit" default:"3"`
 	DefaultMemoryLimit      string            `name:"default_memory_limit" default:"1Gi"`
 	PodEnvironmentConfigMap string            `name:"pod_environment_configmap" default:""`
-	NodeEOLLabel            map[string]string `name:"node_eol_label" default:"lifecycle-status:pending-decommission"`
 	NodeReadinessLabel      map[string]string `name:"node_readiness_label" default:"lifecycle-status:ready"`
 }
 


### PR DESCRIPTION
- use the lack of lifecycle-status: ready label to trigger the migration
- make sure the nodes are examined on start of the operator in order to avoid missing a migration of the set of nodes when the operator is killed in the process.