### PR TITLE
Add PostgreSQL pod name Scalyr sidecar environment

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -446,6 +446,15 @@ func (c *Cluster) generatePodTemplate(
 				VolumeMounts:    volumeMounts,
 				Env: []v1.EnvVar{
 					{
+						Name: "POD_NAME",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "metadata.name",
+							},
+						},
+					},
+					{
 						Name:  "SCALYR_API_KEY",
 						Value: c.OpConfig.ScalyrAPIKey,
 					},


### PR DESCRIPTION
This will allow the Scalyr image to add a custom attribute to shipped
log entries that notes the name of the originating pod.