### PR TITLE
Migrate only master pods. Migrate single masters.

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -91,7 +91,7 @@ func getPodIndex(podName string) (int32, error) {
 }
 
 func (c *Cluster) preScaleDown(newStatefulSet *v1beta1.StatefulSet) error {
-	masterPod, err := c.getRolePods(Master)
+	masterPod, err := c.getRolePods(Master, false)
 	if err != nil {
 		return fmt.Errorf("could not get master pod: %v", err)
 	}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -91,9 +91,12 @@ func getPodIndex(podName string) (int32, error) {
 }
 
 func (c *Cluster) preScaleDown(newStatefulSet *v1beta1.StatefulSet) error {
-	masterPod, err := c.getRolePods(Master, false)
+	masterPod, err := c.getRolePods(Master)
 	if err != nil {
 		return fmt.Errorf("could not get master pod: %v", err)
+	}
+	if len(masterPod) == 0 {
+		return fmt.Errorf("no master pod is running in the cluster")
 	}
 
 	podNum, err := getPodIndex(masterPod[0].Name)

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -101,7 +101,7 @@ func (c *Controller) moveMasterPodsOffNode(node *v1.Node) {
 
 		role, ok := pod.Labels[c.opConfig.PodRoleLabel]
 		if !ok || cluster.PostgresRole(role) != cluster.Master {
-			if ! ok {
+			if !ok {
 				c.logger.Warningf("could not move pod %q: pod has no role", podName)
 			}
 			continue

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -40,7 +40,7 @@ func (c *Controller) nodeAdd(obj interface{}) {
 	c.logger.Debugf("new node has been added: %q (%s)", util.NameFromMeta(node.ObjectMeta), node.Spec.ProviderID)
 	// check if the node became not ready while the operator was down (otherwise we would have caught it in nodeUpdate)
 	if !c.nodeIsReady(node) {
-		c.movePodsOffNode(node)
+		c.moveMasterPodsOffNode(node)
 	}
 }
 
@@ -64,7 +64,7 @@ func (c *Controller) nodeUpdate(prev, cur interface{}) {
 	if !c.nodeIsReady(nodePrev) || c.nodeIsReady(nodeCur) {
 		return
 	}
-	c.movePodsOffNode(nodeCur)
+	c.moveMasterPodsOffNode(nodeCur)
 }
 
 func (c *Controller) nodeIsReady(node *v1.Node) bool {
@@ -72,7 +72,7 @@ func (c *Controller) nodeIsReady(node *v1.Node) bool {
 		util.MapContains(node.Labels, map[string]string{"master": "true"}))
 }
 
-func (c *Controller) movePodsOffNode(node *v1.Node) {
+func (c *Controller) moveMasterPodsOffNode(node *v1.Node) {
 	nodeName := util.NameFromMeta(node.ObjectMeta)
 	c.logger.Infof("moving pods: node %q became unschedulable and does not have a ready label: %q",
 		nodeName, c.opConfig.NodeReadinessLabel)
@@ -95,14 +95,15 @@ func (c *Controller) movePodsOffNode(node *v1.Node) {
 
 	clusters := make(map[*cluster.Cluster]bool)
 	masterPods := make(map[*v1.Pod]*cluster.Cluster)
-	replicaPods := make(map[*v1.Pod]*cluster.Cluster)
 	movedPods := 0
 	for _, pod := range nodePods {
 		podName := util.NameFromMeta(pod.ObjectMeta)
 
 		role, ok := pod.Labels[c.opConfig.PodRoleLabel]
-		if !ok {
-			c.logger.Warningf("could not move pod %q: pod has no role", podName)
+		if !ok || cluster.PostgresRole(role) != cluster.Master {
+			if ! ok {
+				c.logger.Warningf("could not move pod %q: pod has no role", podName)
+			}
 			continue
 		}
 
@@ -116,17 +117,11 @@ func (c *Controller) movePodsOffNode(node *v1.Node) {
 			continue
 		}
 
-		movedPods++
-
 		if !clusters[cl] {
 			clusters[cl] = true
 		}
 
-		if cluster.PostgresRole(role) == cluster.Master {
-			masterPods[pod] = cl
-		} else {
-			replicaPods[pod] = cl
-		}
+		masterPods[pod] = cl
 	}
 
 	for cl := range clusters {
@@ -138,16 +133,8 @@ func (c *Controller) movePodsOffNode(node *v1.Node) {
 
 		if err := cl.MigrateMasterPod(podName); err != nil {
 			c.logger.Errorf("could not move master pod %q: %v", podName, err)
-			movedPods--
-		}
-	}
-
-	for pod, cl := range replicaPods {
-		podName := util.NameFromMeta(pod.ObjectMeta)
-
-		if err := cl.MigrateReplicaPod(podName, node.Name); err != nil {
-			c.logger.Errorf("could not move replica pod %q: %v", podName, err)
-			movedPods--
+		} else {
+			movedPods++
 		}
 	}
 
@@ -155,13 +142,13 @@ func (c *Controller) movePodsOffNode(node *v1.Node) {
 		cl.Unlock()
 	}
 
-	totalPods := len(nodePods)
+	totalPods := len(masterPods)
 
-	c.logger.Infof("%d/%d pods have been moved out from the %q node",
+	c.logger.Infof("%d/%d master pods have been moved out from the %q node",
 		movedPods, totalPods, nodeName)
 
 	if leftPods := totalPods - movedPods; leftPods > 0 {
-		c.logger.Warnf("could not move %d/%d pods from the %q node",
+		c.logger.Warnf("could not move master %d/%d pods from the %q node",
 			leftPods, totalPods, nodeName)
 	}
 }


### PR DESCRIPTION
Avoid migrating replica pods, since they will be handled by the
node draining anyway (the PDB specifies that only masters are to
be kept).

Allow migration of the single-pod clusters.