### PR TITLE
Set node_readiness_label default to an empty value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project is currently in active development. It is however already [used int
 
 There is a talk about this project delivered by Josh Berkus on KubeCon 2017: [Kube-native Postgres](https://www.youtube.com/watch?v=Zn1vd7sQ_bc)
 
-Please, report any issues discovered to htts://github.com/zalando-incubator/postgres-operator/issues.
+Please, report any issues discovered to https://github.com/zalando-incubator/postgres-operator/issues.
 
 ## Running and testing the operator
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project is currently in active development. It is however already [used int
 
 There is a talk about this project delivered by Josh Berkus on KubeCon 2017: [Kube-native Postgres](https://www.youtube.com/watch?v=Zn1vd7sQ_bc)
 
-Please, report any issues discovered to httnodeps://github.com/zalando-incubator/postgres-operator/issues.
+Please, report any issues discovered to htts://github.com/zalando-incubator/postgres-operator/issues.
 
 ## Running and testing the operator
 

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -39,5 +39,5 @@ data:
   pod_terminate_grace_period: 5m
   pdb_name_format: "postgres-{cluster}-pdb"
   node_eol_label: "lifecycle-status:pending-decommission"
-  node_readiness_label: "lifecycle-status:ready"
+  node_readiness_label: ""
   team_api_role_configuration: "log_statement:all"

--- a/manifests/minimal-postgres-manifest.yaml
+++ b/manifests/minimal-postgres-manifest.yaml
@@ -1,7 +1,7 @@
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
-  name: acid-minimal-cluster-recent
+  name: acid-minimal-cluster
 spec:
   teamId: "ACID"
   volume:
@@ -21,4 +21,3 @@ spec:
     foo: zalando
   postgresql:
     version: "10"
-  dockerImage: registry.opensource.zalan.do/acid/spilotest-10:improve-support-for-namespaces-v1

--- a/manifests/minimal-postgres-manifest.yaml
+++ b/manifests/minimal-postgres-manifest.yaml
@@ -1,7 +1,7 @@
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
-  name: acid-minimal-cluster
+  name: acid-minimal-cluster-recent
 spec:
   teamId: "ACID"
   volume:
@@ -21,3 +21,4 @@ spec:
     foo: zalando
   postgresql:
     version: "10"
+  dockerImage: registry.opensource.zalan.do/acid/spilotest-10:improve-support-for-namespaces-v1

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -238,6 +238,9 @@ PatroniInitDBParams:
 
 func (c *Cluster) nodeAffinity() *v1.Affinity {
 	matchExpressions := make([]v1.NodeSelectorRequirement, 0)
+	if len(c.OpConfig.NodeReadinessLabel) == 0 {
+		return nil
+	}
 	for k, v := range c.OpConfig.NodeReadinessLabel {
 		matchExpressions = append(matchExpressions, v1.NodeSelectorRequirement{
 			Key:      k,
@@ -431,8 +434,11 @@ func (c *Cluster) generatePodTemplate(
 		ServiceAccountName:            c.OpConfig.ServiceAccountName,
 		TerminationGracePeriodSeconds: &terminateGracePeriodSeconds,
 		Containers:                    []v1.Container{container},
-		Affinity:                      c.nodeAffinity(),
 		Tolerations:                   c.tolerations(tolerationsSpec),
+	}
+
+	if affinity := c.nodeAffinity(); affinity != nil {
+		podSpec.Affinity = affinity
 	}
 
 	if c.OpConfig.ScalyrAPIKey != "" && c.OpConfig.ScalyrImage != "" {

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -32,7 +32,7 @@ type Resources struct {
 	DefaultCPULimit         string            `name:"default_cpu_limit" default:"3"`
 	DefaultMemoryLimit      string            `name:"default_memory_limit" default:"1Gi"`
 	PodEnvironmentConfigMap string            `name:"pod_environment_configmap" default:""`
-	NodeReadinessLabel      map[string]string `name:"node_readiness_label" default:"lifecycle-status:ready"`
+	NodeReadinessLabel      map[string]string `name:"node_readiness_label" default:""`
 	MaxInstances            int32             `name:"max_instances" default:"-1"`
 	MinInstances            int32             `name:"min_instances" default:"-1"`
 }


### PR DESCRIPTION
Previously, it was set to the lifecycle-status:ready, breaking a
lot of minikube deployments. Also it was not possible before to run
with this label set to an empty value.

Document the effect of the label in the new section of the
documentation.

Addresses #203 