### PR TITLE
Improve infrastructure role definitions

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: bb2d336f3efb57376916e47b585ad55611b5023b79044ced59c762ea35427f19
-updated: 2017-10-10T10:40:56.894070487+02:00
+hash: aa008e00a8cf34fa59a081dd67644319f9d5d077bf4de81aa4a25a2d5b8781a1
+updated: 2018-01-15T15:00:53.231516+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 760741802ad40f49ae9fc4a69ef6706d2527d62e
+  version: 0cebc639926eb91b0192dae4b28bc808417e764c
   subpackages:
   - aws
   - aws/awserr
@@ -104,7 +104,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/Sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,3 +43,4 @@ import:
   - tools/cache
   - tools/clientcmd
   - tools/remotecommand
+- package: gopkg.in/yaml.v2

--- a/manifests/configmap_infrastructure_roles.yaml
+++ b/manifests/configmap_infrastructure_roles.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-infrastructure-roles
+data:
+  batman: |
+    name: batman
+    inrole: [role1, role2]
+    options:
+      - superuser
+      - login
+    parameters:
+      log_statements: all
+  robin: |
+    name: robin
+    inrole:
+      - postgres

--- a/manifests/infrastructure-roles.yaml
+++ b/manifests/infrastructure-roles.yaml
@@ -11,7 +11,8 @@ data:
   # testuser
   user2: dGVzdHVzZXI=
   # foobar
-  password2: Zm9vYmFy
+  password2: c2VjcmV0
+  batman: anVzdGljZQ==
 kind: Secret
 metadata:
   name: postgresql-infrastructure-roles

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -629,10 +629,12 @@ func (c *Cluster) initSystemUsers() {
 	// secrets, therefore, setting flags like SUPERUSER or REPLICATION
 	// is not necessary here
 	c.systemUsers[constants.SuperuserKeyName] = spec.PgUser{
+		Origin:   spec.RoleOriginSystem,
 		Name:     c.OpConfig.SuperUsername,
 		Password: util.RandomPassword(constants.PasswordLength),
 	}
 	c.systemUsers[constants.ReplicationUserKeyName] = spec.PgUser{
+		Origin:   spec.RoleOriginSystem,
 		Name:     c.OpConfig.ReplicationUsername,
 		Password: util.RandomPassword(constants.PasswordLength),
 	}
@@ -653,6 +655,7 @@ func (c *Cluster) initRobotUsers() error {
 		}
 		if _, present := c.pgUsers[username]; !present {
 			c.pgUsers[username] = spec.PgUser{
+				Origin:   spec.RoleOriginManifest,
 				Name:     username,
 				Password: util.RandomPassword(constants.PasswordLength),
 				Flags:    flags,
@@ -696,6 +699,7 @@ func (c *Cluster) initHumanUsers() error {
 		}
 
 		c.pgUsers[username] = spec.PgUser{
+			Origin:		spec.RoleOriginTeamsAPI,
 			Name:       username,
 			Flags:      flags,
 			MemberOf:   memberOf,

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -320,6 +320,10 @@ func (c *Cluster) syncSecrets() error {
 			if err2 != nil {
 				return fmt.Errorf("could not get current secret: %v", err2)
 			}
+			if secretUsername != string(curSecret.Data["username"]) {
+				c.logger.Warningf("secret %q does not contain the role %q", secretSpec.Name, secretUsername)
+				continue
+			}
 			c.logger.Debugf("secret %q already exists, fetching its password", util.NameFromMeta(curSecret.ObjectMeta))
 			if secretUsername == c.systemUsers[constants.SuperuserKeyName].Name {
 				secretUsername = constants.SuperuserKeyName
@@ -331,8 +335,17 @@ func (c *Cluster) syncSecrets() error {
 				userMap = c.pgUsers
 			}
 			pwdUser := userMap[secretUsername]
-			pwdUser.Password = string(curSecret.Data["password"])
-			userMap[secretUsername] = pwdUser
+			// if this secret belongs to the infrastructure role and the password has changed - replace it in the secret
+			if pwdUser.Password != string(curSecret.Data["password"]) && pwdUser.Origin == spec.RoleOriginInfrastructure {
+				c.logger.Debugf("updating the secret %q from the infrastructure roles", secretSpec.Name)
+				if _, err := c.KubeClient.Secrets(secretSpec.Namespace).Update(secretSpec); err != nil {
+					return fmt.Errorf("could not update infrastructure role secret for role %q: %v", secretUsername, err)
+				}
+			} else {
+				// for non-infrastructure role - update the role with the password from the secret
+				pwdUser.Password = string(curSecret.Data["password"])
+				userMap[secretUsername] = pwdUser
+			}
 
 			continue
 		} else {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zalando-incubator/postgres-operator/pkg/util/config"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/constants"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/k8sutil"
+	"gopkg.in/yaml.v2"
 )
 
 func (c *Controller) makeClusterConfig() cluster.Config {
@@ -96,6 +97,14 @@ func (c *Controller) createCRD() error {
 	})
 }
 
+func readDecodedRole(s string) (*spec.PgUser, error) {
+	var result spec.PgUser
+	if err := yaml.Unmarshal([]byte(s), &result); err != nil {
+		return nil, fmt.Errorf("could not decode yaml role: %v", err)
+	}
+	return &result, nil
+}
+
 func (c *Controller) getInfrastructureRoles(rolesSecret *spec.NamespacedName) (result map[string]spec.PgUser, err error) {
 	if *rolesSecret == (spec.NamespacedName{}) {
 		// we don't have infrastructure roles defined, bail out
@@ -110,16 +119,16 @@ func (c *Controller) getInfrastructureRoles(rolesSecret *spec.NamespacedName) (r
 		return nil, fmt.Errorf("could not get infrastructure roles secret: %v", err)
 	}
 
-	data := infraRolesSecret.Data
+	secretData := infraRolesSecret.Data
 	result = make(map[string]spec.PgUser)
 Users:
 	// in worst case we would have one line per user
-	for i := 1; i <= len(data); i++ {
+	for i := 1; i <= len(secretData); i++ {
 		properties := []string{"user", "password", "inrole"}
-		t := spec.PgUser{Origin:spec.RoleOriginInfrastructure}
+		t := spec.PgUser{Origin: spec.RoleOriginInfrastructure}
 		for _, p := range properties {
 			key := fmt.Sprintf("%s%d", p, i)
-			if val, present := data[key]; !present {
+			if val, present := secretData[key]; !present {
 				if p == "user" {
 					// exit when the user name with the next sequence id is absent
 					break Users
@@ -134,11 +143,10 @@ Users:
 				case "inrole":
 					t.MemberOf = append(t.MemberOf, s)
 				default:
-					c.logger.Warningf("unknown key %q", p)
+					c.logger.Warningf("unkonwn key %q", p)
 				}
 			}
-
-			delete(data, key)
+			delete(secretData, key)
 		}
 
 		if t.Name != "" {
@@ -146,10 +154,32 @@ Users:
 		}
 	}
 
-	if len(data) != 0 {
-		c.logger.Warningf("%d unprocessed entries in the infrastructure roles' secret", len(data))
-		c.logger.Info(`infrastructure role entries should be in the {key}{id} format, where {key} can be either of "user", "password", "inrole" and the {id} a monotonically increasing integer starting with 1`)
-		c.logger.Debugf("unprocessed entries: %#v", data)
+	if len(secretData) != 0 {
+		c.logger.Debugf("Extra data in the infrastructure role, checking configmap %v", rolesSecret.Name)
+		// perhaps we have some map entries with usernames, passwords, let's check if we have those users in the configmap
+		if infraRolesMap, err := c.KubeClient.ConfigMaps(rolesSecret.Namespace).Get(rolesSecret.Name, metav1.GetOptions{}); err == nil {
+			// we have a configmap with username - json description, let's read and decode it
+			for role, s := range infraRolesMap.Data {
+				if roleDescr, err := readDecodedRole(s); err != nil {
+					// check if we have a a password in a configmap
+					return nil, fmt.Errorf("could not decode role description: %v", err)
+				} else {
+					c.logger.Debugf("found role description for role %q: %+v", role, roleDescr)
+					if passwd, ok := secretData[role]; ok {
+						roleDescr.Password = string(passwd)
+						delete(secretData, role)
+					}
+					roleDescr.Name = role
+					roleDescr.Origin = spec.RoleOriginInfrastructure
+					result[role] = *roleDescr
+				}
+			}
+		}
+		if len(secretData) > 0 {
+			c.logger.Warningf("%d unprocessed entries in the infrastructure roles' secret", len(secretData))
+			c.logger.Info(`infrastructure role entries should be in the {key}{id} format, where {key} can be either of "user", "password", "inrole" and the {id} a monotonically increasing integer starting with 1`)
+			c.logger.Debugf("unprocessed entries: %#v", secretData)
+		}
 	}
 
 	return result, nil

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -116,7 +116,7 @@ Users:
 	// in worst case we would have one line per user
 	for i := 1; i <= len(data); i++ {
 		properties := []string{"user", "password", "inrole"}
-		t := spec.PgUser{}
+		t := spec.PgUser{Origin:spec.RoleOriginInfrastructure}
 		for _, p := range properties {
 			key := fmt.Sprintf("%s%d", p, i)
 			if val, present := data[key]; !present {

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -223,6 +223,7 @@ type postgresqlCopy Postgresql
 
 // UnmarshalJSON converts a JSON into the PostgreSQL object.
 func (p *Postgresql) UnmarshalJSON(data []byte) error {
+	fmt.Printf("unmarshaling %s\n", string(data))
 	var tmp postgresqlCopy
 
 	err := json.Unmarshal(data, &tmp)

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -29,6 +29,7 @@ const (
 )
 
 type RoleOrigin int
+
 const (
 	RoleOriginSystem = iota
 	RoleOriginInfrastructure
@@ -67,12 +68,12 @@ type PodEvent struct {
 
 // PgUser contains information about a single user.
 type PgUser struct {
-	Origin 	   RoleOrigin
-	Name       string
-	Password   string
-	Flags      []string
-	MemberOf   []string
-	Parameters map[string]string
+	Origin     RoleOrigin        `yaml:"-"`
+	Name       string            `yaml:"-"`
+	Password   string            `yaml:"-"`
+	Flags      []string          `yaml:"options"`
+	MemberOf   []string          `yaml:"inrole"`
+	Parameters map[string]string `yaml:"parameters"`
 }
 
 // PgUserMap maps user names to the definitions.

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -28,6 +28,15 @@ const (
 	EventSync   EventType = "SYNC"
 )
 
+type RoleOrigin int
+const (
+	RoleOriginSystem = iota
+	RoleOriginInfrastructure
+	RoleOriginManifest
+	RoleOriginTeamsAPI
+	RoleOriginUnknown
+)
+
 // ClusterEvent carries the payload of the Cluster TPR events.
 type ClusterEvent struct {
 	EventTime time.Time
@@ -58,6 +67,7 @@ type PodEvent struct {
 
 // PgUser contains information about a single user.
 type PgUser struct {
+	Origin 	   RoleOrigin
 	Name       string
 	Password   string
 	Flags      []string


### PR DESCRIPTION
Allow defining infrasturcture roles via configmaps.
See manifests/configmap_infrastructure_roles.yaml for an example.
Passwords should still be specified in the infrastructure roles
secret.

In addition, merge role definitions for the roles with the same
name using roles origins instead of implicit reliance on the order
of their initialization in the operator.