### PR TITLE
Allow configuring a NodeSelector in the Postgres kind

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -282,6 +282,7 @@ func (c *Cluster) generatePodTemplate(
 	tolerationsSpec *[]v1.Toleration,
 	pgParameters *spec.PostgresqlParam,
 	patroniParameters *spec.Patroni,
+	nodeSelector *map[string]string,
 	cloneDescription *spec.CloneDescription,
 	dockerImage *string,
 	customPodEnvVars map[string]string,
@@ -433,6 +434,7 @@ func (c *Cluster) generatePodTemplate(
 		Containers:                    []v1.Container{container},
 		Affinity:                      c.nodeAffinity(),
 		Tolerations:                   c.tolerations(tolerationsSpec),
+		NodeSelector:                  *nodeSelector,
 	}
 
 	if c.OpConfig.ScalyrAPIKey != "" && c.OpConfig.ScalyrImage != "" {
@@ -531,7 +533,7 @@ func (c *Cluster) generateStatefulSet(spec *spec.PostgresSpec) (*v1beta1.Statefu
 			customPodEnvVars = cm.Data
 		}
 	}
-	podTemplate := c.generatePodTemplate(resourceRequirements, resourceRequirementsScalyrSidecar, &spec.Tolerations, &spec.PostgresqlParam, &spec.Patroni, &spec.Clone, &spec.DockerImage, customPodEnvVars)
+	podTemplate := c.generatePodTemplate(resourceRequirements, resourceRequirementsScalyrSidecar, &spec.Tolerations, &spec.PostgresqlParam, &spec.Patroni, &spec.NodeSelector, &spec.Clone, &spec.DockerImage, customPodEnvVars)
 	volumeClaimTemplate, err := generatePersistentVolumeClaimTemplate(spec.Volume.Size, spec.Volume.StorageClass)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate volume claim template: %v", err)

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -105,6 +105,7 @@ type PostgresSpec struct {
 	ClusterName         string               `json:"-"`
 	Databases           map[string]string    `json:"databases,omitempty"`
 	Tolerations         []v1.Toleration      `json:"tolerations,omitempty"`
+	NodeSelector        map[string]string    `json:"NodeSelector,omitempty"`
 }
 
 // PostgresqlList defines a list of PostgreSQL clusters.

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -138,7 +138,10 @@ var unmarshalCluster = []struct {
         "superuser",
         "createdb"
       ]
-    },
+	},
+	"NodeSelector": {
+		"cloud.google.com/gke-nodepool": "default-pool"
+	},
     "allowedSourceRanges": [
       "127.0.0.1/32"
     ],
@@ -227,6 +230,7 @@ var unmarshalCluster = []struct {
 				AllowedSourceRanges: []string{"127.0.0.1/32"},
 				NumberOfInstances:   2,
 				Users:               map[string]UserFlags{"zalando": {"superuser", "createdb"}},
+				NodeSelector:        map[string]string{"cloud.google.com/gke-nodepool": "default-pool"},
 				MaintenanceWindows: []MaintenanceWindow{{
 					Everyday:  false,
 					Weekday:   time.Monday,
@@ -252,7 +256,7 @@ var unmarshalCluster = []struct {
 			},
 			Error: nil,
 		},
-		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"}}}`), nil},
+		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"},"NodeSelector":{"cloud.google.com/gke-nodepool":"default-pool"}}}`), nil},
 	{
 		[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1","metadata": {"name": "teapot-testcluster1"}, "spec": {"teamId": "acid"}}`),
 		Postgresql{


### PR DESCRIPTION
This add support for adding the NodeSelector label to the Postgresql kind.  
We use this in a GKE cluster which has two node pools, default and preemptible, to have the Postgres pods scheduled only on the normal nodes.  