### PR TITLE
Use cluster UID as a suffix to the WAL bucket.

### DIFF
--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -55,6 +55,7 @@ type Patroni struct {
 // CloneDescription describes which cluster the new should clone and up to which point in time
 type CloneDescription struct {
 	ClusterName  string `json:"cluster,omitempty"`
+	Uid          string `json:"uid,omitempty"`
 	EndTimestamp string `json:"timestamp,omitempty"`
 }
 


### PR DESCRIPTION
Populate `WAL_BUCKET_SCOPE_SUFFIX` Spilo environment variable with the cluster manifest UID, which will be used as a suffix for the S3 bucket. The end goal is to allow deleting a cluster and then deploying another one with the same name without the latest one reusing the S3 bucket of the previous one.