### PR TITLE
Define the operator RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,29 @@ We can use the generated secret of the `postgres` robot user to connect to our `
     $ export PGPASSWORD=$(kubectl --context minikube get secret postgres.acid-minimal-cluster.credentials -o 'jsonpath={.data.password}' | base64 -d)
     $ psql -U postgres
 
+### Role-based access control for the operator
+
+The `manifests/operator-rbac.yaml` defines cluster roles and bindigns needed for the operator to function under access control restrictions. To deploy the operator with this RBAC policy use:
+
+```bash
+kubectl create -f manifests/configmap.yaml 
+kubectl create -f manifests/operator-rbac.yaml
+kubectl create -f manifests/postgres-operator.yaml 
+kubectl create -f manifests/minimal-postgres-manifest.yaml
+```
+
+Note that the service account in `operator-rbac.yaml` is named `zalando-postgres-operator` and not
+the `operator` default that is created in the `serviceaccount.yaml`. So you will have to change the `service_account_name` in the operator configmap and `serviceAccountName` in the postgres-operator deployment appropriately.
+
+This is done intentionally, as to avoid breaking those setups that
+already work with the default `operator` account. In the future the operator should ideally be run under the
+`zalando-postgres-operator` service account. 
+
+The service account defined in  `operator-rbac.yaml` acquires some privileges not really
+used by the operator (i.e. we only need list and watch on configmaps),
+this is also done intentionally to avoid breaking things if someone
+decides to configure the same service account in the operator's
+configmap to run postgres clusters.
 
 ### Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ We can use the generated secret of the `postgres` robot user to connect to our `
 
 ### Role-based access control for the operator
 
-The `manifests/operator-rbac.yaml` defines cluster roles and bindigns needed for the operator to function under access control restrictions. To deploy the operator with this RBAC policy use:
+The `manifests/operator-rbac.yaml` defines cluster roles and bindings needed for the operator to function under access control restrictions. To deploy the operator with this RBAC policy use:
 
 ```bash
 kubectl create -f manifests/configmap.yaml 

--- a/manifests/operator-rbac.yaml
+++ b/manifests/operator-rbac.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zalando-postgres-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: zalando-postgres-operator
+rules:
+- apiGroups:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - pods
+  - services
+  - statefulsets
+  - persistentvolumeclaims
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zalando-postgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator
+subjects:
+- kind: ServiceAccount
+  name: zalando-postgres-operator

--- a/manifests/operator-rbac.yaml
+++ b/manifests/operator-rbac.yaml
@@ -89,7 +89,7 @@ rules:
   - get
   - patch
 - apiGroups:
-  - ""
+  - apps
   resources:
   - statefulsets
   verbs:

--- a/manifests/operator-rbac.yaml
+++ b/manifests/operator-rbac.yaml
@@ -96,6 +96,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""

--- a/manifests/operator-rbac.yaml
+++ b/manifests/operator-rbac.yaml
@@ -33,9 +33,17 @@ rules:
   - ""
   resources:
   - endpoints
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
+  - update
   - delete
   - get
 - apiGroups:
@@ -90,6 +98,12 @@ rules:
   - get
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
@@ -109,5 +123,7 @@ roleRef:
   name: zalando-postgres-operator
 subjects:
 - kind: ServiceAccount
+# note: the cluster role binding needs to be defined
+# for every namespace the operator service account lives in.
   name: zalando-postgres-operator
   namespace: default

--- a/manifests/operator-rbac.yaml
+++ b/manifests/operator-rbac.yaml
@@ -82,7 +82,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - service
+  - services
   verbs:
   - create
   - delete

--- a/manifests/operator-rbac.yaml
+++ b/manifests/operator-rbac.yaml
@@ -2,10 +2,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: zalando-postgres-operator
+  namespace: default
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
+kind: ClusterRole
 metadata:
   name: zalando-postgres-operator
 rules:
@@ -20,19 +21,23 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - "*"
+  - create
+  - get
 - apiGroups:
   - ""
   resources:
   - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - endpoints
-  - pods
-  - services
-  - statefulsets
-  - persistentvolumeclaims
   - secrets
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
 - apiGroups:
   - ""
   resources:
@@ -42,21 +47,67 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update # only for resizing AWS volumes
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - service
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: zalando-postgres-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: zalando-postgres-operator
 subjects:
 - kind: ServiceAccount
   name: zalando-postgres-operator
+  namespace: default

--- a/manifests/operator-rbac.yaml
+++ b/manifests/operator-rbac.yaml
@@ -56,7 +56,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: operator
+  name: zalando-postgres-operator
 subjects:
 - kind: ServiceAccount
   name: zalando-postgres-operator


### PR DESCRIPTION
Note that the account here is named zalando-postgres-operator and not
the 'operator' default that is created in the serviceaccount.yaml and
also used by the operator configmap to create new postgres clusters.

This is done intentionally, as to avoid breaking those setups that
already work. Ideally, the operator should be run under the
zalando-postgres-operator service account. However, the service account
used to run Postgres clusters does not require all those privileges and
is described at
https://github.com/zalando/patroni/blob/master/kubernetes/patroni_k8s.yaml

The service account defined here acquires some privileges not really
used by the operator (i.e. we only need list and watch on configmaps),
this is also done intentionally to avoid breaking things if someone
decides to configure the same service account in the operator's
configmap to run postgres clusters.