### PR TITLE
Change the suffix delimiter to slash.

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -505,7 +505,7 @@ func (c *Cluster) generatePodTemplate(
 
 func getWALBucketScopeSuffix(uid string) string {
 	if uid != "" {
-		return fmt.Sprintf("-%s", uid)
+		return fmt.Sprintf("/%s", uid)
 	}
 	return ""
 }


### PR DESCRIPTION
This allows using S3 API in order to simplify finding all
folders that are different only by a suffix, since the
suffix delimiter will not occur in the suffix itself.