### PR TITLE
Remove the check for the clone cluster name.

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -34,8 +34,8 @@ func TestInitRobotUsers(t *testing.T) {
 		{
 			manifestUsers: map[string]spec.UserFlags{"foo": {"superuser", "createdb"}},
 			infraRoles:    map[string]spec.PgUser{"foo": {Origin: spec.RoleOriginInfrastructure, Name: "foo", Password: "bar"}},
-			result: map[string]spec.PgUser{"foo": {Origin: spec.RoleOriginInfrastructure,  Name: "foo", Password: "bar"}},
-			err: nil,
+			result:        map[string]spec.PgUser{"foo": {Origin: spec.RoleOriginInfrastructure, Name: "foo", Password: "bar"}},
+			err:           nil,
 		},
 		{
 			manifestUsers: map[string]spec.UserFlags{"!fooBar": {"superuser", "createdb"}},

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -259,15 +259,6 @@ func (p *Postgresql) UnmarshalJSON(data []byte) error {
 		tmp2.Error = err
 		tmp2.Status = ClusterStatusInvalid
 	}
-	// The assumption below is that a cluster to clone, if any, belongs to the same team
-	if tmp2.Spec.Clone.ClusterName != "" {
-		_, err := extractClusterName(tmp2.Spec.Clone.ClusterName, tmp2.Spec.TeamID)
-		if err != nil {
-			tmp2.Error = fmt.Errorf("%s for the cluster to clone", err)
-			tmp2.Spec.Clone = CloneDescription{}
-			tmp2.Status = ClusterStatusInvalid
-		}
-	}
 	*p = tmp2
 
 	return nil

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -78,8 +78,9 @@ const (
 )
 
 const (
-	serviceNameMaxLength = 63
-	clusterNameMaxLength = serviceNameMaxLength - len("-repl")
+	serviceNameMaxLength   = 63
+	clusterNameMaxLength   = serviceNameMaxLength - len("-repl")
+	serviceNameRegexString = `^[a-z]([-a-z0-9]*[a-z0-9])?$`
 )
 
 // Postgresql defines PostgreSQL Custom Resource Definition Object.
@@ -134,7 +135,7 @@ type PostgresqlList struct {
 
 var (
 	weekdays         = map[string]int{"Sun": 0, "Mon": 1, "Tue": 2, "Wed": 3, "Thu": 4, "Fri": 5, "Sat": 6}
-	serviceNameRegex = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
+	serviceNameRegex = regexp.MustCompile(serviceNameRegexString)
 )
 
 func parseTime(s string) (time.Time, error) {
@@ -238,7 +239,8 @@ func extractClusterName(clusterName string, teamName string) (string, error) {
 		return "", fmt.Errorf("name cannot be longer than %d characters", clusterNameMaxLength)
 	}
 	if !serviceNameRegex.MatchString(clusterName) {
-		return "", fmt.Errorf("name must confirm to a valid service name (DNS-1035)")
+		return "", fmt.Errorf("name must confirm to DNS-1035, regex used for validation is %q",
+			serviceNameRegexString)
 	}
 
 	return clusterName[teamNameLen+1:], nil
@@ -248,7 +250,8 @@ func validateCloneClusterDescription(clone *CloneDescription) error {
 	// when cloning from the basebackup (no end timestamp) check that the cluster name is a valid service name
 	if clone.ClusterName != "" && clone.EndTimestamp == "" {
 		if !serviceNameRegex.MatchString(clone.ClusterName) {
-			return fmt.Errorf("clone cluster name must confirm to a valid service name (DNS-1035)")
+			return fmt.Errorf("clone cluster name must confirm to DNS-1035, regex used for validation is %q",
+				serviceNameRegexString)
 		}
 		if len(clone.ClusterName) > serviceNameMaxLength {
 			return fmt.Errorf("clone cluster name must be no longer than %d characters", serviceNameMaxLength)

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -280,13 +280,14 @@ var unmarshalCluster = []struct {
 			},
 			Spec: PostgresSpec{
 				TeamID:      "acid",
-				Clone:       CloneDescription{},
+				Clone:       CloneDescription{
+					ClusterName: "team-batman",
+				},
 				ClusterName: "testcluster1",
 			},
-			Status: ClusterStatusInvalid,
-			Error:  errors.New("name must match {TEAM}-{NAME} format for the cluster to clone"),
+			Error:  nil,
 		},
-		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`), err: nil},
+		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{"cluster":"team-batman"}}}`), err: nil},
 	{[]byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1"`),
 		Postgresql{},
 		[]byte{},

--- a/pkg/spec/postgresql_test.go
+++ b/pkg/spec/postgresql_test.go
@@ -44,7 +44,7 @@ var clusterNames = []struct {
 	{"test-my-name", "test", "my-name", nil},
 	{"my-team-another-test", "my-team", "another-test", nil},
 	{"------strange-team-cluster", "-----", "strange-team-cluster",
-		errors.New("name must confirm to a valid service name (DNS-1035)")},
+		errors.New(`name must confirm to DNS-1035, regex used for validation is "^[a-z]([-a-z0-9]*[a-z0-9])?$"`)},
 	{"fooobar-fooobarfooobarfooobarfooobarfooobarfooobarfooobarfooobar", "fooobar", "",
 		errors.New("name cannot be longer than 58 characters")},
 	{"acid-test", "test", "", errors.New("name must match {TEAM}-{NAME} format")},
@@ -60,7 +60,7 @@ var cloneClusterDescriptions = []struct {
 }{
 	{&CloneDescription{"foo+bar", "", "NotEmpty"}, nil},
 	{&CloneDescription{"foo+bar", "", ""},
-		errors.New("clone cluster name must confirm to a valid service name (DNS-1035)")},
+		errors.New(`clone cluster name must confirm to DNS-1035, regex used for validation is "^[a-z]([-a-z0-9]*[a-z0-9])?$"`)},
 	{&CloneDescription{"foobar123456789012345678901234567890123456789012345678901234567890", "", ""},
 		errors.New("clone cluster name must be no longer than 63 characters")},
 	{&CloneDescription{"foobar", "", ""}, nil},
@@ -419,7 +419,7 @@ func TestCloneClusterDescription(t *testing.T) {
 	for _, tt := range cloneClusterDescriptions {
 		if err := validateCloneClusterDescription(tt.in); err != nil {
 			if tt.err == nil || err.Error() != tt.err.Error() {
-				t.Errorf("testCloneClusterDescription expected error: %v, got: %v")
+				t.Errorf("testCloneClusterDescription expected error: %v, got: %v", tt.err, err)
 			}
 		} else if tt.err != nil {
 			t.Errorf("Expected error: %v", tt.err)


### PR DESCRIPTION
Clone cluster name may not adhere to the same rules as the names of the
clusters managed by the operator, as it might be just a name inside the
S3 bucket.