### PR TITLE
Remove team from statefulset selector

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -293,8 +293,6 @@ func (c *Cluster) Create() error {
 	return nil
 }
 
-// TODO: forbid changing the label selector on the statefulset, as it would cripple replacements
-// due to the fact that the new statefulset won't be able to pick up old pods with non-matching labels.
 func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *compareStatefulsetResult {
 	reasons := make([]string, 0)
 	var match, needsRollUpdate, needsReplace bool
@@ -342,6 +340,20 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *comp
 		needsRollUpdate = true
 		reasons = append(reasons, "new statefulset's metadata labels doesn't match the current one")
 	}
+	if (c.Statefulset.Spec.Selector != nil) && (statefulSet.Spec.Selector != nil) {
+		if !reflect.DeepEqual(c.Statefulset.Spec.Selector.MatchLabels, statefulSet.Spec.Selector.MatchLabels) {
+			// forbid introducing new labels in the selector on the new statefulset, as it would cripple replacements
+			// due to the fact that the new statefulset won't be able to pick up old pods with non-matching labels.
+			if !util.MapContains(c.Statefulset.Spec.Selector.MatchLabels, statefulSet.Spec.Selector.MatchLabels) {
+				c.logger.Warningf("new statefulset introduces extra labels in the label selector, cannot continue")
+				return &compareStatefulsetResult{}
+			}
+		}
+		needsReplace = true
+		needsRollUpdate = true
+		reasons = append(reasons, "new statefulset's selector doesn't match the current one")
+	}
+
 	if !reflect.DeepEqual(c.Statefulset.Spec.Template.Annotations, statefulSet.Spec.Template.Annotations) {
 		needsRollUpdate = true
 		needsReplace = true

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -293,6 +293,8 @@ func (c *Cluster) Create() error {
 	return nil
 }
 
+// TODO: forbid changing the label selector on the statefulset, as it would cripple replacements
+// due to the fact that the new statefulset won't be able to pick up old pods with non-matching labels.
 func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *compareStatefulsetResult {
 	reasons := make([]string, 0)
 	var match, needsRollUpdate, needsReplace bool

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -564,6 +564,7 @@ func (c *Cluster) generateStatefulSet(spec *spec.PostgresSpec) (*v1beta1.Statefu
 		},
 		Spec: v1beta1.StatefulSetSpec{
 			Replicas:             &numberOfInstances,
+			Selector:             c.labelsSelector(),
 			ServiceName:          c.serviceName(Master),
 			Template:             *podTemplate,
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{*volumeClaimTemplate},

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -355,6 +355,10 @@ func (c *Cluster) labelsSet(shouldAddExtraLabels bool) labels.Set {
 	return labels.Set(lbls)
 }
 
+func (c *Cluster) labelsSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{c.labelsSet(false), nil}
+}
+
 func (c *Cluster) roleLabelsSet(role PostgresRole) labels.Set {
 	lbls := c.labelsSet(false)
 	lbls[c.OpConfig.PodRoleLabel] = string(role)


### PR DESCRIPTION
I was never supposed to be there, but implicitely statefulset creates a selector out of meta.labels field. That is the problem with recent Kubernetes, since statefulset cannot pick up pods with non-matching label selectors, and we rely on statefulset picking up old pods after statefulset replacement.