### PR TITLE
Deploy service account for pod creation on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ By default, the operator watches the namespace it is deployed to. You can change
 
 Note that for an operator to manage pods in the watched namespace, the operator's service account (as specified in the operator deployment manifest) has to have appropriate privileges to access the watched namespace. The operator may not be able to function in the case it watches all namespaces but lacks access rights to any of them (except Kubernetes system namespaces like `kube-system`). The reason is that for multiple namespaces operations such as 'list pods' execute at the cluster scope and fail at the first violation of access rights.
 
-The watched namespace also needs to have a (possibly different) service account in the case database pods need to talk to the Kubernetes API (e.g. when using Kubernetes-native configuration of Patroni).
+The watched namespace also needs to have a (possibly different) service account in the case database pods need to talk to the Kubernetes API (e.g. when using Kubernetes-native configuration of Patroni). The operator checks that the `pod_service_account_name` exists in the target namespace, and, if not, deploys there the `pod_service_account_definition`. In this definition, the operator overwrites the account's name to match `pod_service_account_name` and the namespace to match the target namespace. The operator  performs **no** further syncing of this account.
 
 ### Create ConfigMap
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,16 @@ By default, the operator watches the namespace it is deployed to. You can change
 
 Note that for an operator to manage pods in the watched namespace, the operator's service account (as specified in the operator deployment manifest) has to have appropriate privileges to access the watched namespace. The operator may not be able to function in the case it watches all namespaces but lacks access rights to any of them (except Kubernetes system namespaces like `kube-system`). The reason is that for multiple namespaces operations such as 'list pods' execute at the cluster scope and fail at the first violation of access rights.
 
-The watched namespace also needs to have a (possibly different) service account in the case database pods need to talk to the Kubernetes API (e.g. when using Kubernetes-native configuration of Patroni). The operator checks that the `pod_service_account_name` exists in the target namespace, and, if not, deploys there the `pod_service_account_definition`. In this definition, the operator overwrites the account's name to match `pod_service_account_name` and the namespace to match the target namespace. The operator  performs **no** further syncing of this account.
+The watched namespace also needs to have a (possibly different) service account in the case database pods need to talk to the Kubernetes API (e.g. when using Kubernetes-native configuration of Patroni). The operator checks that the `pod_service_account_name` exists in the target namespace, and, if not, deploys there the `pod_service_account_definition` from the operator [`Config`](pkg/util/config/config.go) with the default value of:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+ name: operator
+```
+
+ In this definition, the operator overwrites the account's name to match `pod_service_account_name` and the `default` namespace to match the target namespace. The operator  performs **no** further syncing of this account.
 
 ### Create ConfigMap
 

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -7,7 +7,6 @@ data:
   # if neither is set or evaluates to the empty string, listen to the operator's own namespace
   # if set to the "*", listen to all namespaces
   # watched_namespace: development
-  service_account_name: operator
   cluster_labels: application:spilo
   cluster_name_label: version
   pod_role_label: spilo-role

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -256,6 +256,11 @@ func (c *Cluster) Create() error {
 	}
 	c.logger.Infof("pod disruption budget %q has been successfully created", util.NameFromMeta(pdb.ObjectMeta))
 
+	if err = c.syncPodServiceAccounts(); err != nil {
+		return fmt.Errorf("could not sync pod service accounts: %v", err)
+	}
+	c.logger.Infof("pod service accounts have been successfully synced")
+
 	if c.Statefulset != nil {
 		return fmt.Errorf("statefulset already exists in the cluster")
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -208,13 +208,11 @@ func (c *Cluster) createPodServiceAccounts() error {
 	_, err := c.KubeClient.ServiceAccounts(c.Namespace).Get(podServiceAccountName, metav1.GetOptions{})
 
 	if err != nil {
-		c.logger.Warnf("the pod service account %q cannot be retrieved in the namespace %q. Stateful sets in the namespace may be unable to create pods. Error: %v", podServiceAccountName, c.Namespace, err)
+		c.logger.Infof("the pod service account %q cannot be retrieved in the namespace %q; stateful sets in the namespace may be unable to create pods. Trying to deploy the account.", podServiceAccountName, c.Namespace)
 
 		// get a separate copy of service account
 		// to prevent a race condition when setting a namespace for many clusters
 		sa := *c.PodServiceAccount
-		sa.SetNamespace(c.Namespace)
-
 		_, err = c.KubeClient.ServiceAccounts(c.Namespace).Create(&sa)
 		if err != nil {
 			return fmt.Errorf("cannot deploy the pod service account %q defined in the config map to the %q namespace: %v", podServiceAccountName, c.Namespace, err)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -203,12 +203,13 @@ func (c *Cluster) initUsers() error {
 func (c *Cluster) createPodServiceAccounts() error {
 
 	podServiceAccountName := c.Config.OpConfig.PodServiceAccountName
-	c.setProcessName(fmt.Sprintf("creating pod service account in the namespace %v", c.Namespace))
-
 	_, err := c.KubeClient.ServiceAccounts(c.Namespace).Get(podServiceAccountName, metav1.GetOptions{})
 
 	if err != nil {
-		c.logger.Infof("the pod service account %q cannot be retrieved in the namespace %q; stateful sets in the namespace may be unable to create pods. Trying to deploy the account.", podServiceAccountName, c.Namespace)
+
+		c.setProcessName(fmt.Sprintf("creating pod service account in the namespace %v", c.Namespace))
+
+		c.logger.Infof("the pod service account %q cannot be retrieved in the namespace %q. Trying to deploy the account.", podServiceAccountName, c.Namespace)
 
 		// get a separate copy of service account
 		// to prevent a race condition when setting a namespace for many clusters

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -435,7 +435,7 @@ func (c *Cluster) generatePodTemplate(
 	terminateGracePeriodSeconds := int64(c.OpConfig.PodTerminateGracePeriod.Seconds())
 
 	podSpec := v1.PodSpec{
-		ServiceAccountName:            c.OpConfig.ServiceAccountName,
+		ServiceAccountName:            c.OpConfig.PodServiceAccountName,
 		TerminationGracePeriodSeconds: &terminateGracePeriodSeconds,
 		Containers:                    []v1.Container{container},
 		Tolerations:                   c.tolerations(tolerationsSpec),

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -44,12 +44,6 @@ func (c *Cluster) Sync(newSpec *spec.Postgresql) (err error) {
 		return
 	}
 
-	c.logger.Debugf("syncing service accounts")
-	if err = c.syncPodServiceAccounts(); err != nil {
-		err = fmt.Errorf("could not sync service accounts: %v", err)
-		return
-	}
-
 	c.logger.Debugf("syncing services")
 	if err = c.syncServices(); err != nil {
 		err = fmt.Errorf("could not sync services: %v", err)
@@ -107,34 +101,6 @@ func (c *Cluster) syncServices() error {
 	}
 
 	return nil
-}
-
-/*
-  Ensures the service account required by StatefulSets to create pods exists in all namespaces watched by the operator.
-*/
-func (c *Cluster) syncPodServiceAccounts() error {
-
-	podServiceAccount := c.Config.OpConfig.PodServiceAccountName
-	c.setProcessName("syncing pod service account in the watched namespaces")
-
-	_, err := c.KubeClient.ServiceAccounts(c.Namespace).Get(podServiceAccount, metav1.GetOptions{})
-
-	if err != nil {
-		c.logger.Warnf("the pod service account %q is absent from the namespace %q. Stateful sets in the namespace are unable to create pods.", podServiceAccount, c.Namespace)
-
-		c.OpConfig.PodServiceAccount.SetNamespace(c.Namespace)
-
-		_, err = c.KubeClient.ServiceAccounts(c.Namespace).Create(c.OpConfig.PodServiceAccount)
-		if err != nil {
-			c.logger.Warnf("cannot deploy the pod service account %q defined in the config map to the %q namespace: %v", podServiceAccount, c.Namespace, err)
-		} else {
-			c.logger.Infof("successfully deployed the pod service account %q to the %q namespace", podServiceAccount, c.Namespace)
-		}
-	} else {
-		c.logger.Infof("successfully found the service account %q used to create pods to the namespace %q", podServiceAccount, c.Namespace)
-	}
-
-	return err
 }
 
 func (c *Cluster) syncService(role PostgresRole) error {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,7 +131,7 @@ func (c *Controller) initPodServiceAccount() {
 		c.opConfig.PodServiceAccount = obj.(*v1.ServiceAccount)
 	}
 
-	// actual service accounts are deployed lazily at the time of cluster creation or sync
+	// actual service accounts are deployed at the time of Postgres/Spilo cluster creation
 }
 
 func (c *Controller) initController() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -120,6 +120,17 @@ func (c *Controller) initOperatorConfig() {
 }
 
 func (c *Controller) initPodServiceAccount() {
+
+	if c.opConfig.PodServiceAccountDefinition == "" {
+		c.opConfig.PodServiceAccountDefinition = `
+		{ "apiVersion": "v1", 
+		  "kind": "ServiceAccount", 
+		  "metadata": { 
+				 "name": "operator" 
+		   }
+		}`
+	}
+
 	// re-uses k8s internal parsing. See k8s client-go issue #193 for explanation
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, groupVersionKind, err := decode([]byte(c.opConfig.PodServiceAccountDefinition), nil, nil)
@@ -134,6 +145,7 @@ func (c *Controller) initPodServiceAccount() {
 		if c.PodServiceAccount.Name != c.opConfig.PodServiceAccountName {
 			c.logger.Warnf("in the operator config map, the pod service account name %v does not match the name %v given in the account definition; using the former for consistency", c.opConfig.PodServiceAccountName, c.PodServiceAccount.Name)
 			c.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
+			c.PodServiceAccount.Namespace = ""
 		}
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -145,8 +145,8 @@ func (c *Controller) initPodServiceAccount() {
 		if c.PodServiceAccount.Name != c.opConfig.PodServiceAccountName {
 			c.logger.Warnf("in the operator config map, the pod service account name %v does not match the name %v given in the account definition; using the former for consistency", c.opConfig.PodServiceAccountName, c.PodServiceAccount.Name)
 			c.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
-			c.PodServiceAccount.Namespace = ""
 		}
+		c.PodServiceAccount.Namespace = ""
 	}
 
 	// actual service accounts are deployed at the time of Postgres/Spilo cluster creation

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -128,7 +128,7 @@ func (c *Controller) initPodServiceAccount() {
 	case groupVersionKind.Kind != "ServiceAccount":
 		panic(fmt.Errorf("pod service account definiton in the operator config map defines another type of resource: %v", groupVersionKind.Kind))
 	default:
-		c.opConfig.PodServiceAccount = obj.(*v1.ServiceAccount)
+		c.opConfig.PodServiceAccount = *obj.(*v1.ServiceAccount)
 		// ensure consistent naming of the account
 		c.opConfig.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,8 +131,10 @@ func (c *Controller) initPodServiceAccount() {
 		panic(fmt.Errorf("pod service account definiton in the operator config map defines another type of resource: %v", groupVersionKind.Kind))
 	default:
 		c.PodServiceAccount = obj.(*v1.ServiceAccount)
-		// ensure consistent naming of the account
-		c.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
+		if c.PodServiceAccount.Name != c.opConfig.PodServiceAccountName {
+			c.logger.Warnf("in the operator config map, the pod service account name %v does not match the name %v given in the account definition; using the former for consistency", c.opConfig.PodServiceAccountName, c.PodServiceAccount.Name)
+			c.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
+		}
 	}
 
 	// actual service accounts are deployed at the time of Postgres/Spilo cluster creation

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -51,6 +51,8 @@ type Controller struct {
 	lastClusterSyncTime int64
 
 	workerLogs map[uint32]ringlog.RingLogger
+
+	PodServiceAccount *v1.ServiceAccount
 }
 
 // NewController creates a new controller
@@ -128,9 +130,9 @@ func (c *Controller) initPodServiceAccount() {
 	case groupVersionKind.Kind != "ServiceAccount":
 		panic(fmt.Errorf("pod service account definiton in the operator config map defines another type of resource: %v", groupVersionKind.Kind))
 	default:
-		c.opConfig.PodServiceAccount = *obj.(*v1.ServiceAccount)
+		c.PodServiceAccount = obj.(*v1.ServiceAccount)
 		// ensure consistent naming of the account
-		c.opConfig.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
+		c.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
 	}
 
 	// actual service accounts are deployed at the time of Postgres/Spilo cluster creation

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -129,6 +129,8 @@ func (c *Controller) initPodServiceAccount() {
 		panic(fmt.Errorf("pod service account definiton in the operator config map defines another type of resource: %v", groupVersionKind.Kind))
 	default:
 		c.opConfig.PodServiceAccount = obj.(*v1.ServiceAccount)
+		// ensure consistent naming of the account
+		c.opConfig.PodServiceAccount.Name = c.opConfig.PodServiceAccountName
 	}
 
 	// actual service accounts are deployed at the time of Postgres/Spilo cluster creation

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -26,6 +26,7 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 		RestConfig:          c.config.RestConfig,
 		OpConfig:            config.Copy(c.opConfig),
 		InfrastructureRoles: infrastructureRoles,
+		PodServiceAccount:   c.PodServiceAccount,
 	}
 }
 

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/zalando-incubator/postgres-operator/pkg/spec"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // CRD describes CustomResourceDefinition specific configuration parameters
@@ -67,21 +68,25 @@ type Config struct {
 	Resources
 	Auth
 	Scalyr
-	WatchedNamespace          string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
-	EtcdHost                  string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
-	DockerImage               string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
-	ServiceAccountName        string `name:"service_account_name" default:"operator"`
-	DbHostedZone              string `name:"db_hosted_zone" default:"db.example.com"`
-	EtcdScope                 string `name:"etcd_scope" default:"service"`
-	WALES3Bucket              string `name:"wal_s3_bucket"`
-	KubeIAMRole               string `name:"kube_iam_role"`
-	DebugLogging              bool   `name:"debug_logging" default:"true"`
-	EnableDBAccess            bool   `name:"enable_database_access" default:"true"`
-	EnableTeamsAPI            bool   `name:"enable_teams_api" default:"true"`
-	EnableTeamSuperuser       bool   `name:"enable_team_superuser" default:"false"`
-	TeamAdminRole             string `name:"team_admin_role" default:"admin"`
-	EnableMasterLoadBalancer  bool   `name:"enable_master_load_balancer" default:"true"`
-	EnableReplicaLoadBalancer bool   `name:"enable_replica_load_balancer" default:"false"`
+	PodServiceAccount *v1.ServiceAccount
+	WatchedNamespace  string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
+	EtcdHost          string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
+	DockerImage       string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
+	// re-use one account for both Spilo pods and the operator; this grants extra privileges to pods
+	ServiceAccountName          string `name:"service_account_name" default:"operator"`
+	PodServiceAccountName       string `name:"pod_service_account_name" default:"operator"`
+	PodServiceAccountDefinition string `name:"pod_service_account_definition" default:"apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: operator\n"`
+	DbHostedZone                string `name:"db_hosted_zone" default:"db.example.com"`
+	EtcdScope                   string `name:"etcd_scope" default:"service"`
+	WALES3Bucket                string `name:"wal_s3_bucket"`
+	KubeIAMRole                 string `name:"kube_iam_role"`
+	DebugLogging                bool   `name:"debug_logging" default:"true"`
+	EnableDBAccess              bool   `name:"enable_database_access" default:"true"`
+	EnableTeamsAPI              bool   `name:"enable_teams_api" default:"true"`
+	EnableTeamSuperuser         bool   `name:"enable_team_superuser" default:"false"`
+	TeamAdminRole               string `name:"team_admin_role" default:"admin"`
+	EnableMasterLoadBalancer    bool   `name:"enable_master_load_balancer" default:"true"`
+	EnableReplicaLoadBalancer   bool   `name:"enable_replica_load_balancer" default:"false"`
 	// deprecated and kept for backward compatibility
 	EnableLoadBalancer       *bool             `name:"enable_load_balancer" default:"true"`
 	MasterDNSNameFormat      stringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/zalando-incubator/postgres-operator/pkg/spec"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 // CRD describes CustomResourceDefinition specific configuration parameters
@@ -68,10 +67,10 @@ type Config struct {
 	Resources
 	Auth
 	Scalyr
-	PodServiceAccount v1.ServiceAccount // has to be struct value, not a pointer
-	WatchedNamespace  string            `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
-	EtcdHost          string            `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
-	DockerImage       string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
+
+	WatchedNamespace string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
+	EtcdHost         string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
+	DockerImage      string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
 	// re-use one account for both Spilo pods and the operator; this grants extra privileges to pods
 	PodServiceAccountName       string `name:"pod_service_account_name" default:"operator"`
 	PodServiceAccountDefinition string `name:"pod_service_account_definition" default:"apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: operator\n"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -68,10 +68,10 @@ type Config struct {
 	Resources
 	Auth
 	Scalyr
-	PodServiceAccount *v1.ServiceAccount
-	WatchedNamespace  string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
-	EtcdHost          string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
-	DockerImage       string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
+	PodServiceAccount v1.ServiceAccount // has to be struct value, not a pointer
+	WatchedNamespace  string            `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
+	EtcdHost          string            `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
+	DockerImage       string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
 	// re-use one account for both Spilo pods and the operator; this grants extra privileges to pods
 	ServiceAccountName          string `name:"service_account_name" default:"operator"`
 	PodServiceAccountName       string `name:"pod_service_account_name" default:"operator"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -73,7 +73,6 @@ type Config struct {
 	EtcdHost          string            `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
 	DockerImage       string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
 	// re-use one account for both Spilo pods and the operator; this grants extra privileges to pods
-	ServiceAccountName          string `name:"service_account_name" default:"operator"`
 	PodServiceAccountName       string `name:"pod_service_account_name" default:"operator"`
 	PodServiceAccountDefinition string `name:"pod_service_account_definition" default:"apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: operator\n"`
 	DbHostedZone                string `name:"db_hosted_zone" default:"db.example.com"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	WatchedNamespace string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
 	EtcdHost         string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
 	DockerImage      string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
-	// re-use one account for both Spilo pods and the operator; this grants extra privileges to pods
+	// default name `operator` enables backward compatibility with the older ServiceAccountName field
 	PodServiceAccountName       string `name:"pod_service_account_name" default:"operator"`
 	PodServiceAccountDefinition string `name:"pod_service_account_definition" default:"apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: operator\n"`
 	DbHostedZone                string `name:"db_hosted_zone" default:"db.example.com"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -72,8 +72,9 @@ type Config struct {
 	EtcdHost         string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
 	DockerImage      string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
 	// default name `operator` enables backward compatibility with the older ServiceAccountName field
-	PodServiceAccountName       string `name:"pod_service_account_name" default:"operator"`
-	PodServiceAccountDefinition string `name:"pod_service_account_definition" default:"apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: operator\n"`
+	PodServiceAccountName string `name:"pod_service_account_name" default:"operator"`
+	// value of this string must be valid JSON or YAML; see initPodServiceAccount
+	PodServiceAccountDefinition string `name:"pod_service_account_definition" default:""`
 	DbHostedZone                string `name:"db_hosted_zone" default:"db.example.com"`
 	EtcdScope                   string `name:"etcd_scope" default:"service"`
 	WALES3Bucket                string `name:"wal_s3_bucket"`


### PR DESCRIPTION
Stateful sets need a service account to create Spilo pods. This PR automates deployment of such an account, thereby reducing manual work required to deploy a database.