### PR TITLE
Fix a bug with syncing services

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -108,11 +108,10 @@ func (c *Cluster) syncService(role PostgresRole) error {
 
 	svc, err := c.KubeClient.Services(c.Namespace).Get(c.serviceName(role), metav1.GetOptions{})
 	if err == nil {
-
+		c.Services[role] = svc
 		desiredSvc := c.generateService(role, &c.Spec)
 		match, reason := k8sutil.SameService(svc, desiredSvc)
 		if match {
-			c.Services[role] = svc
 			return nil
 		}
 		c.logServiceChanges(role, svc, desiredSvc, false, reason)


### PR DESCRIPTION
Avoid showing "there is no service in the cluster" when syncing a
service for the cluster if the operator has been restarted after
the cluster had been created.