### PR TITLE
Annotate StatefulSets with pending rolling update status flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+_manifests
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -348,10 +348,9 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *v1beta1.StatefulSet) *comp
 				c.logger.Warningf("new statefulset introduces extra labels in the label selector, cannot continue")
 				return &compareStatefulsetResult{}
 			}
+			needsReplace = true
+			reasons = append(reasons, "new statefulset's selector doesn't match the current one")
 		}
-		needsReplace = true
-		needsRollUpdate = true
-		reasons = append(reasons, "new statefulset's selector doesn't match the current one")
 	}
 
 	if !reflect.DeepEqual(c.Statefulset.Spec.Template.Annotations, statefulSet.Spec.Template.Annotations) {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -34,8 +34,8 @@ func TestInitRobotUsers(t *testing.T) {
 		{
 			manifestUsers: map[string]spec.UserFlags{"foo": {"superuser", "createdb"}},
 			infraRoles:    map[string]spec.PgUser{"foo": {Origin: spec.RoleOriginInfrastructure, Name: "foo", Password: "bar"}},
-			result: map[string]spec.PgUser{"foo": {Origin: spec.RoleOriginInfrastructure,  Name: "foo", Password: "bar"}},
-			err: nil,
+			result:        map[string]spec.PgUser{"foo": {Origin: spec.RoleOriginInfrastructure, Name: "foo", Password: "bar"}},
+			err:           nil,
 		},
 		{
 			manifestUsers: map[string]spec.UserFlags{"!fooBar": {"superuser", "createdb"}},

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -564,6 +564,7 @@ func (c *Cluster) generateStatefulSet(spec *spec.PostgresSpec) (*v1beta1.Statefu
 		},
 		Spec: v1beta1.StatefulSetSpec{
 			Replicas:             &numberOfInstances,
+			Selector:             c.labelsSelector(),
 			ServiceName:          c.serviceName(Master),
 			Template:             *podTemplate,
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{*volumeClaimTemplate},

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	RollingUpdateStatefulsetAnnotationKey = "zalando-postgres-operator-rolling-update"
+	RollingUpdateStatefulsetAnnotationKey = "zalando-postgres-operator-rolling-update-required"
 )
 
 func (c *Cluster) listResources() error {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -247,6 +247,7 @@ func (c *Cluster) syncStatefulSet() error {
 
 		podsRollingUpdateRequired = (len(pods) > 0)
 		if podsRollingUpdateRequired {
+			c.logger.Warningf("found pods from the previous statefulset: trigger rolling update")
 			c.applyRollingUpdateFlagforStatefulSet(podsRollingUpdateRequired)
 		}
 		c.logger.Infof("created missing statefulset %q", util.NameFromMeta(sset.ObjectMeta))

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zalando-incubator/postgres-operator/pkg/util/constants"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/k8sutil"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/retryutil"
+	"reflect"
 )
 
 // OAuthTokenGetter provides the method for fetching OAuth tokens
@@ -172,7 +173,10 @@ func (c *Cluster) logStatefulSetChanges(old, new *v1beta1.StatefulSet, isUpdate 
 			util.NameFromMeta(old.ObjectMeta),
 		)
 	}
-	c.logger.Debugf("diff\n%s\n", util.PrettyDiff(old.Spec, new.Spec))
+	if !reflect.DeepEqual(old.Annotations, new.Annotations) {
+		c.logger.Debugf("metadata.annotation diff\n%s\n", util.PrettyDiff(old.Annotations, new.Annotations))
+	}
+	c.logger.Debugf("spec diff\n%s\n", util.PrettyDiff(old.Spec, new.Spec))
 
 	if len(reasons) > 0 {
 		for _, reason := range reasons {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -21,7 +22,6 @@ import (
 	"github.com/zalando-incubator/postgres-operator/pkg/util/constants"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/k8sutil"
 	"github.com/zalando-incubator/postgres-operator/pkg/util/retryutil"
-	"reflect"
 )
 
 // OAuthTokenGetter provides the method for fetching OAuth tokens

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -39,6 +39,10 @@ func NewSecretOauthTokenGetter(kubeClient *k8sutil.KubernetesClient,
 	return &SecretOauthTokenGetter{kubeClient, OAuthTokenSecretName}
 }
 
+const (
+	podControllerRevisionHashLabel = "controller-revision-hash"
+)
+
 func (g *SecretOauthTokenGetter) getOAuthToken() (string, error) {
 	//TODO: we can move this function to the Controller in case it will be needed there. As for now we use it only in the Cluster
 	// Temporary getting postgresql-operator secret from the NamespaceDefault
@@ -429,4 +433,57 @@ func (c *Cluster) GetSpec() (*spec.Postgresql, error) {
 
 func (c *Cluster) patroniUsesKubernetes() bool {
 	return c.OpConfig.EtcdHost == ""
+}
+
+func (c *Cluster) setPendingRollingUpgrade(val bool) {
+	if c.pendingRollingUpdate == nil {
+		c.pendingRollingUpdate = new(bool)
+	}
+	*c.pendingRollingUpdate = val
+	c.logger.Debugf("pending rolling upgrade was set to %b", val)
+}
+
+// resolvePendingRollingUpdate figures out if rolling upgrade is necessary
+// based on the states of the cluster statefulset and pods
+func (c *Cluster) resolvePendingRollingUpdate(sset *v1beta1.StatefulSet) error {
+	// XXX: it looks like we will always trigger a rolling update if the
+	// pods are on a different revision from a statefulset, even if the
+	// statefulset change that caused it didn't require a rolling update
+	// originally.
+	if c.pendingRollingUpdate != nil {
+		return nil
+	}
+	c.logger.Debugf("evaluating rolling upgrade requirement")
+	effectiveRevision := sset.Status.UpdateRevision
+	if effectiveRevision == "" {
+		if sset.Status.CurrentRevision == "" {
+			c.logger.Debugf("statefulset doesn't have a current revision, no rolling upgrade")
+			// the statefulset does not have a currentRevision, it must be new; hence, no rollingUpdate
+			c.setPendingRollingUpgrade(false)
+			return nil
+		}
+		effectiveRevision = sset.Status.CurrentRevision
+	}
+
+	// fetch all pods related to this cluster
+	pods, err := c.listPods()
+	if err != nil {
+		return err
+	}
+	// check their revisions
+	for _, pod := range pods {
+		podRevision, present := pod.Labels[podControllerRevisionHashLabel]
+		// empty or missing revision indicates a new pod - doesn't need a rolling upgrade
+		if !present || podRevision == "" {
+			continue
+		}
+		c.logger.Debugf("observing pod revision %q vs statefulset revision %q", podRevision, effectiveRevision)
+		if podRevision != effectiveRevision {
+			// pod is on a different revision - trigger the rolling upgrade
+			c.setPendingRollingUpgrade(true)
+			return nil
+		}
+	}
+	c.setPendingRollingUpgrade(false)
+	return nil
 }

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -355,6 +355,10 @@ func (c *Cluster) labelsSet(shouldAddExtraLabels bool) labels.Set {
 	return labels.Set(lbls)
 }
 
+func (c *Cluster) labelsSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{c.labelsSet(false), nil}
+}
+
 func (c *Cluster) roleLabelsSet(role PostgresRole) labels.Set {
 	lbls := c.labelsSet(false)
 	lbls[c.OpConfig.PodRoleLabel] = string(role)

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -131,8 +131,13 @@ func SameService(cur, new *v1.Service) (match bool, reason string) {
 	oldELBAnnotation := cur.Annotations[constants.ElbTimeoutAnnotationName]
 	newELBAnnotation := new.Annotations[constants.ElbTimeoutAnnotationName]
 
-	if oldDNSAnnotation != newDNSAnnotation || oldELBAnnotation != newELBAnnotation {
-		return false, fmt.Sprintf("new service's %q annotation doesn't match the current one", constants.ZalandoDNSNameAnnotation)
+	if oldDNSAnnotation != newDNSAnnotation {
+		return false, fmt.Sprintf("new service's %q annotation value %q doesn't match the current one %q",
+			constants.ZalandoDNSNameAnnotation, newDNSAnnotation, oldDNSAnnotation)
+	}
+	if oldELBAnnotation != newELBAnnotation {
+		return false, fmt.Sprintf("new service's %q annotation value %q doesn't match the current one %q",
+			constants.ElbTimeoutAnnotationName, oldELBAnnotation, newELBAnnotation)
 	}
 
 	return true, ""


### PR DESCRIPTION
Store pending rolling update flag in the cluster's StatefulSet annotation and clear it once the rolling update finished. Doing that allows us to resume an incomplete rolling update even if the instance of the operator that started it is no longer running.

That required to amend the StatefulSet comparison logic to act on StatefulSet annotations.

Also, if there is a failure to update the running StatefulSet with the rolling update flag value, the operator checks the value of the flag as stored inside the Cluster definition and reset the flag in the actual running StatefulSet if the in-memory flag is False. That way, if the actual rolling update succeeds, but the update of the rolling update flag fails, the rolling update won't be repeated.

Fix a few issues with the services:
- when comparing service definitions, do not stop right away when both have empty sourceRanges; compare the ELB timeout annotations alongside the ELB DNSName ones.
- do not ignore enableMasterLoadBalancer flag in the PostgreSQL cluster definition.

Replace the StrategicMergePatch used to patch annotations with a Merge+JSON one, since the former did not work reliably in all occasions (producing failures when the field that is the contents of the patch is missing from the definition to patch).

Addresses #272 .