### PR TITLE
Deprecate old LB options, fix endpoint sync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,11 +276,17 @@ For instance, of a cluster manifest has 1 instance and the min_instances is set 
 
 ### Load balancers 
 
-For any Postgresql/Spilo cluster an operator creates two separate k8s services: one for the master pod and one for replica pods. To expose these services to an outer network, one can attach load balancers to them by setting `enableMasterLoadBalancer` and/or `enableReplicaLoadBalancer` to `true` in the cluster manifest. In the case any of these variables is omitted from the manifest, the operator configmap's settings `enable_master_load_balancer` and `enable_replica_load_balancer` apply. Note that the operator settings affect all Postgresql services running in a namespace watched by the operator.
+For any Postgresql/Spilo cluster, the operator creates two separate k8s services: one for the master pod and one for
+replica pods. To expose these services to an outer network, one can attach load balancers to them by setting
+`enableMasterLoadBalancer` and/or `enableReplicaLoadBalancer` to `true` in the cluster manifest. In the case any of
+these variables are omitted from the manifest, the operator configmap's settings `enable_master_load_balancer` and
+`enable_replica_load_balancer` apply. Note that the operator settings affect all Postgresql services running in a
+namespace watched by the operator.
 
-For backward compatibility with already configured clusters we maintain in a cluster manifest older parameter names, namely `useLoadBalancer` for enabling the master service's load balancer and `replicaLoadBalancer` for the replica service. If set, these params take precedence over the newer `enableMasterLoadBalancer` and `enableReplicaLoadBalancer`. Note that in older versions of the operator (before PR #258) `replicaLoadBalancer` was responsible for both creating the replica service and attaching an LB to it; now the service is always created (since k8s service typically is free in the cloud setting), and this param only attaches an LB (that typically costs money).
+###### Deprecated parameters
 
-For the same reason of compatibility, we maintain the `enable_load_balancer` setting in the operator config map that was previously used to attach a LB to the master service. Its value is examined after the deprecated `useLoadBalancer` setting from the Postgresql manifest but before the recommended `enableMasterLoadBalancer`. There is no equivalent option for the replica service since the service used to be always created with a load balancer.
+Parameters `useLoadBalancer` and `replicaLoadBalancer` in the PostgreSQL manifest, as well as `enable_load_balancer`
+are deprecated and take no effect, producing a warning when specified in the operator or cluster configuration.
 
 # Setup development environment
 

--- a/README.md
+++ b/README.md
@@ -285,8 +285,12 @@ namespace watched by the operator.
 
 ###### Deprecated parameters
 
-Parameters `useLoadBalancer` and `replicaLoadBalancer` in the PostgreSQL manifest, as well as `enable_load_balancer`
-are deprecated and take no effect, producing a warning when specified in the operator or cluster configuration.
+Parameters `useLoadBalancer` and `replicaLoadBalancer` in the PostgreSQL manifest are deprecated. To retain
+compatibility with the old manifests they take affect in the absense of new `enableMasterLoadBalancer` and
+`enableReplicaLoadBalancer` parameters (that is, if either of the new ones is present - all deprecated parameters are
+ignored). The operator configuration parameter `enable_load_balancer` is ignored in all cases.
+
+`
 
 # Setup development environment
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -170,6 +170,10 @@ func (c *Cluster) setStatus(status spec.PostgresStatus) {
 	}
 }
 
+func (c *Cluster) isNewCluster() bool {
+	return c.Status == spec.ClusterStatusCreating
+}
+
 // initUsers populates c.systemUsers and c.pgUsers maps.
 func (c *Cluster) initUsers() error {
 	c.setProcessName("initializing users")
@@ -255,11 +259,15 @@ func (c *Cluster) Create() error {
 		if c.Endpoints[role] != nil {
 			return fmt.Errorf("%s endpoint already exists in the cluster", role)
 		}
-		ep, err = c.createEndpoint(role, false)
-		if err != nil {
-			return fmt.Errorf("could not create %s endpoint: %v", role, err)
+		if role == Master {
+			// replica endpoint will be created by the replica service. Master endpoint needs to be created by us,
+			// since the corresponding master service doesn't define any selectors.
+			ep, err = c.createEndpoint(role)
+			if err != nil {
+				return fmt.Errorf("could not create %s endpoint: %v", role, err)
+			}
+			c.logger.Infof("endpoint %q has been successfully created", util.NameFromMeta(ep.ObjectMeta))
 		}
-		c.logger.Infof("endpoint %q has been successfully created", util.NameFromMeta(ep.ObjectMeta))
 
 		if c.Services[role] != nil {
 			return fmt.Errorf("service already exists in the cluster")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -255,7 +255,7 @@ func (c *Cluster) Create() error {
 		if c.Endpoints[role] != nil {
 			return fmt.Errorf("%s endpoint already exists in the cluster", role)
 		}
-		ep, err = c.createEndpoint(role)
+		ep, err = c.createEndpoint(role, false)
 		if err != nil {
 			return fmt.Errorf("could not create %s endpoint: %v", role, err)
 		}

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -683,12 +683,6 @@ func (c *Cluster) shouldCreateLoadBalancerForService(role PostgresRole, spec *sp
 
 	case Replica:
 
-		// deprecated option takes priority for backward compatibility
-		if spec.ReplicaLoadBalancer != nil {
-			c.logger.Debugf("The Postgres manifest for the cluster %v sets the deprecated `replicaLoadBalancer` param. Consider using the `enableReplicaLoadBalancer` instead.", c.Name)
-			return *spec.ReplicaLoadBalancer
-		}
-
 		// if the value is explicitly set in a Postgresql manifest, follow this setting
 		if spec.EnableReplicaLoadBalancer != nil {
 			return *spec.EnableReplicaLoadBalancer
@@ -699,16 +693,8 @@ func (c *Cluster) shouldCreateLoadBalancerForService(role PostgresRole, spec *sp
 
 	case Master:
 
-		if spec.UseLoadBalancer != nil {
-			c.logger.Debugf("The Postgres manifest for the cluster %v sets the deprecated `useLoadBalancer` param. Consider using the `enableMasterLoadBalancer` instead.", c.Name)
-			return *spec.UseLoadBalancer
-		}
-
-		// `enable_load_balancer`` governs LB for a master service
-		// there is no equivalent deprecated operator option for the replica LB
-		if c.OpConfig.EnableLoadBalancer != nil {
-			c.logger.Debugf("The operator configmap sets the deprecated `enable_load_balancer` param. Consider using the `enable_master_load_balancer` or `enable_replica_load_balancer` instead.")
-			return *c.OpConfig.EnableLoadBalancer
+		if spec.EnableMasterLoadBalancer != nil {
+			return *spec.EnableMasterLoadBalancer
 		}
 
 		return c.OpConfig.EnableMasterLoadBalancer

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -65,23 +65,6 @@ func TestCreateLoadBalancerLogic(t *testing.T) {
 			opConfig: config.Config{EnableReplicaLoadBalancer: false},
 			result:   false,
 		},
-		{
-			subtest:  "old format, load balancer is enabled for replica, but is ignored",
-			role:     Replica,
-			spec:     &spec.PostgresSpec{ReplicaLoadBalancer: True()},
-			opConfig: config.Config{},
-			result:   false,
-		},
-		{
-			subtest: "old format is ignored, new one is applied",
-			role:    Replica,
-			spec: &spec.PostgresSpec{
-				ReplicaLoadBalancer:       True(),
-				EnableReplicaLoadBalancer: False(),
-			},
-			opConfig: config.Config{},
-			result:   false,
-		},
 	}
 	for _, tt := range tests {
 		cluster.OpConfig = tt.opConfig

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -66,21 +66,21 @@ func TestCreateLoadBalancerLogic(t *testing.T) {
 			result:   false,
 		},
 		{
-			subtest:  "old format, load balancer is enabled for replica",
+			subtest:  "old format, load balancer is enabled for replica, but is ignored",
 			role:     Replica,
 			spec:     &spec.PostgresSpec{ReplicaLoadBalancer: True()},
 			opConfig: config.Config{},
-			result:   true,
+			result:   false,
 		},
 		{
-			subtest: "old format has priority",
+			subtest: "old format is ignored, new one is applied",
 			role:    Replica,
 			spec: &spec.PostgresSpec{
 				ReplicaLoadBalancer:       True(),
 				EnableReplicaLoadBalancer: False(),
 			},
 			opConfig: config.Config{},
-			result:   true,
+			result:   false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -343,11 +343,17 @@ func (c *Cluster) deleteService(role PostgresRole) error {
 	return nil
 }
 
-func (c *Cluster) createEndpoint(role PostgresRole) (*v1.Endpoints, error) {
+func (c *Cluster) createEndpoint(role PostgresRole, sync bool) (*v1.Endpoints, error) {
+	var (
+		subsets []v1.EndpointSubset
+	)
 	c.setProcessName("creating endpoint")
-	subsets := make([]v1.EndpointSubset, 0)
-	if role == Master {
-		//TODO: set subsets to the master
+	if sync {
+		subsets = c.generateEndpointSubsets(role)
+	} else {
+		// Patroni will populate the master endpoint for the new cluster
+		// The replica endpoint will be filled-in by the service selector.
+		subsets = make([]v1.EndpointSubset, 0)
 	}
 	endpointsSpec := c.generateEndpoint(role, subsets)
 
@@ -359,6 +365,34 @@ func (c *Cluster) createEndpoint(role PostgresRole) (*v1.Endpoints, error) {
 	c.Endpoints[role] = endpoints
 
 	return endpoints, nil
+}
+
+func (c *Cluster) generateEndpointSubsets(role PostgresRole) []v1.EndpointSubset {
+	result := make([]v1.EndpointSubset, 0)
+	pods, err := c.getRolePods(role)
+	if err != nil {
+		if role == Master {
+			c.logger.Warningf("could not obtain the address for %s pod: %v", role, err)
+		} else {
+			c.logger.Warningf("could not obtain the addresses for %s pods: %v", role, err)
+		}
+		return result
+	}
+
+	endPointAddresses := make([]v1.EndpointAddress, 0)
+	for _, pod := range pods {
+		endPointAddresses = append(endPointAddresses, v1.EndpointAddress{IP: pod.Status.PodIP})
+	}
+	if len(endPointAddresses) > 0 {
+		result = append(result, v1.EndpointSubset{
+			Addresses: endPointAddresses,
+			Ports:     []v1.EndpointPort{{"postgresql", 5432, "TCP"}},
+		})
+	} else if role == Master {
+		c.logger.Warningf("master is not running, generated master endpoint does not contain any addresses")
+	}
+
+	return result
 }
 
 func (c *Cluster) createPodDisruptionBudget() (*policybeta1.PodDisruptionBudget, error) {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -343,12 +343,12 @@ func (c *Cluster) deleteService(role PostgresRole) error {
 	return nil
 }
 
-func (c *Cluster) createEndpoint(role PostgresRole, sync bool) (*v1.Endpoints, error) {
+func (c *Cluster) createEndpoint(role PostgresRole) (*v1.Endpoints, error) {
 	var (
 		subsets []v1.EndpointSubset
 	)
 	c.setProcessName("creating endpoint")
-	if sync {
+	if !c.isNewCluster() {
 		subsets = c.generateEndpointSubsets(role)
 	} else {
 		// Patroni will populate the master endpoint for the new cluster

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -164,7 +164,7 @@ func (c *Cluster) syncEndpoint(role PostgresRole) error {
 
 	c.logger.Infof("could not find the cluster's %s endpoint", role)
 
-	if ep, err := c.createEndpoint(role, true); err != nil {
+	if ep, err := c.createEndpoint(role); err != nil {
 		if k8sutil.ResourceAlreadyExists(err) {
 			c.logger.Infof("%s endpoint %q already exists", role, util.NameFromMeta(ep.ObjectMeta))
 			ep, err := c.KubeClient.Endpoints(c.Namespace).Get(c.endpointName(role), metav1.GetOptions{})

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -164,7 +164,7 @@ func (c *Cluster) syncEndpoint(role PostgresRole) error {
 
 	c.logger.Infof("could not find the cluster's %s endpoint", role)
 
-	if ep, err := c.createEndpoint(role); err != nil {
+	if ep, err := c.createEndpoint(role, true); err != nil {
 		if k8sutil.ResourceAlreadyExists(err) {
 			c.logger.Infof("%s endpoint %q already exists", role, util.NameFromMeta(ep.ObjectMeta))
 			ep, err := c.KubeClient.Endpoints(c.Namespace).Get(c.endpointName(role), metav1.GetOptions{})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -111,12 +111,21 @@ func (c *Controller) initOperatorConfig() {
 	}
 
 	c.opConfig = config.NewFromMap(configMapData)
+	c.warnOnDeprecatedOperatorParameters()
 
 	scalyrAPIKey := os.Getenv("SCALYR_API_KEY")
 	if scalyrAPIKey != "" {
 		c.opConfig.ScalyrAPIKey = scalyrAPIKey
 	}
 
+}
+
+// warningOnDeprecatedParameters emits warnings upon finding deprecated parmaters
+func (c *Controller) warnOnDeprecatedOperatorParameters() {
+	if c.opConfig.EnableLoadBalancer != nil {
+		c.logger.Warningf("Operator configuration parameter 'enable_load_balancer' is deprecated and takes no effect. " +
+			"Consider using the 'enable_master_load_balancer' or 'enable_replica_load_balancer' instead.")
+	}
 }
 
 func (c *Controller) initPodServiceAccount() {

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -287,6 +287,28 @@ func (c *Controller) processClusterEventsQueue(idx int, stopCh <-chan struct{}, 
 	}
 }
 
+func (c *Controller) warnOnDeprecatedPostgreSQLSpecParameters(spec *spec.PostgresSpec) {
+
+	deprecate := func(deprecated, replacement string) {
+		c.logger.Warningf("Parameter %q is deprecated and takes no effect. Consider setting %q instead")
+	}
+
+	noeffect := func(param string, explanation string) {
+		c.logger.Warningf("Parameter %q takes no effect. %s", param, explanation)
+	}
+
+	if spec.UseLoadBalancer != nil {
+		deprecate("useLoadBalancer", "enableMasterLoadBalancer")
+	}
+	if spec.ReplicaLoadBalancer != nil {
+		deprecate("replicaLoadBalancer", "enableReplicaLoadBalancer")
+	}
+
+	if len(spec.MaintenanceWindows) > 0 {
+		noeffect("maintenanceWindows", "Not implemented.")
+	}
+}
+
 func (c *Controller) queueClusterEvent(old, new *spec.Postgresql, eventType spec.EventType) {
 	var (
 		uid          types.UID

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -301,7 +301,7 @@ func (c *Controller) processClusterEventsQueue(idx int, stopCh <-chan struct{}, 
 func (c *Controller) warnOnDeprecatedPostgreSQLSpecParameters(spec *spec.PostgresSpec) {
 
 	deprecate := func(deprecated, replacement string) {
-		c.logger.Warningf("Parameter %q is deprecated. Consider setting %q instead")
+		c.logger.Warningf("Parameter %q is deprecated. Consider setting %q instead", deprecated, replacement)
 	}
 
 	noeffect := func(param string, explanation string) {

--- a/pkg/controller/postgresql_test.go
+++ b/pkg/controller/postgresql_test.go
@@ -1,0 +1,43 @@
+package controller
+
+import (
+	"github.com/zalando-incubator/postgres-operator/pkg/spec"
+	"reflect"
+	"testing"
+)
+
+var (
+	True  bool = true
+	False bool = false
+)
+
+func TestMergeDeprecatedPostgreSQLSpecParameters(t *testing.T) {
+	c := NewController(&spec.ControllerConfig{})
+
+	tests := []struct {
+		name  string
+		in    *spec.PostgresSpec
+		out   *spec.PostgresSpec
+		error string
+	}{
+		{
+			"Check that old parameters propagate values to the new ones",
+			&spec.PostgresSpec{UseLoadBalancer: &True, ReplicaLoadBalancer: &True},
+			&spec.PostgresSpec{UseLoadBalancer: &True, ReplicaLoadBalancer: &True,
+				EnableMasterLoadBalancer: &True, EnableReplicaLoadBalancer: &True},
+			"New parameters should be set from the values of old ones",
+		},
+		{
+			"Check that new parameters are not set when both old and new ones are present",
+			&spec.PostgresSpec{UseLoadBalancer: &True, EnableReplicaLoadBalancer: &True},
+			&spec.PostgresSpec{UseLoadBalancer: &True, EnableReplicaLoadBalancer: &True},
+			"New parameters should remain unchanged when both old and new are present",
+		},
+	}
+	for _, tt := range tests {
+		result := c.mergeDeprecatedPostgreSQLSpecParameters(tt.in)
+		if !reflect.DeepEqual(result, tt.out) {
+			t.Errorf("%s: %v", tt.name, tt.error)
+		}
+	}
+}

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -88,7 +88,7 @@ type Config struct {
 	EnableMasterLoadBalancer    bool   `name:"enable_master_load_balancer" default:"true"`
 	EnableReplicaLoadBalancer   bool   `name:"enable_replica_load_balancer" default:"false"`
 	// deprecated and kept for backward compatibility
-	EnableLoadBalancer       *bool             `name:"enable_load_balancer" default:"true"`
+	EnableLoadBalancer       *bool             `name:"enable_load_balancer"`
 	MasterDNSNameFormat      stringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
 	ReplicaDNSNameFormat     stringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
 	PDBNameFormat            stringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`


### PR DESCRIPTION
- deprecate useLoadBalancer, replicaLoadBalancer from the manifest
  and enable_load_balancer from the operator configuration. Those
  options become no-op with this commit.
- Make sure the endpoint being created during the sync receives proper
  addresses subset. This is more critical for the replicas, as for the
  masters Patroni will normally re-create the endpoint before the
  operator.
- Update the README and unit tests.