### PR TITLE
Avoid terminating delete on errors.

### DIFF
--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -230,9 +230,7 @@ func (c *Controller) processEvent(event spec.ClusterEvent) {
 		teamName := strings.ToLower(cl.Spec.TeamID)
 
 		c.curWorkerCluster.Store(event.WorkerID, cl)
-		if err := cl.Delete(); err != nil {
-			lg.Errorf("could not delete cluster: %v", err)
-		}
+		cl.Delete()
 
 		func() {
 			defer c.clustersMu.Unlock()


### PR DESCRIPTION
When there is an error happening upon deletion of the Kubernetes object
belonging to the cluster being removed, it makes no sense to abort the
deletion: the manifest will be removed anyway, therefore all the objects
after the one we aborted at will stay forever.