### PR TITLE
Use Patroni API to set bootstrap-only options.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -866,8 +866,8 @@ func (c *Cluster) GetStatus() *spec.ClusterStatus {
 	}
 }
 
-// ManualFailover does manual failover to a candidate pod
-func (c *Cluster) ManualFailover(curMaster *v1.Pod, candidate spec.NamespacedName) error {
+// Switchover does a switchover (via Patroni) to a candidate pod
+func (c *Cluster) Switchover(curMaster *v1.Pod, candidate spec.NamespacedName) error {
 	c.logger.Debugf("failing over from %q to %q", curMaster.Name, candidate)
 
 	podLabelErr := make(chan error)
@@ -889,7 +889,7 @@ func (c *Cluster) ManualFailover(curMaster *v1.Pod, candidate spec.NamespacedNam
 		}
 	}()
 
-	if err := c.patroni.Failover(curMaster, candidate.Name); err != nil {
+	if err := c.patroni.Switchover(curMaster, candidate.Name); err != nil {
 		close(stopCh)
 		return fmt.Errorf("could not failover: %v", err)
 	}

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -232,7 +232,7 @@ func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 		}
 
 		masterCandidateName := util.NameFromMeta(pod.ObjectMeta)
-		if err := c.ManualFailover(oldMaster, masterCandidateName); err != nil {
+		if err := c.Switchover(oldMaster, masterCandidateName); err != nil {
 			return fmt.Errorf("could not failover to pod %q: %v", masterCandidateName, err)
 		}
 	} else {
@@ -330,7 +330,7 @@ func (c *Cluster) recreatePods() error {
 	if masterPod != nil {
 		// failover if we have not observed a master pod when re-creating former replicas.
 		if newMasterPod == nil && len(replicas) > 0 {
-			if err := c.ManualFailover(masterPod, masterCandidate(replicas)); err != nil {
+			if err := c.Switchover(masterPod, masterCandidate(replicas)); err != nil {
 				c.logger.Warningf("could not perform failover: %v", err)
 			}
 		} else if newMasterPod == nil && len(replicas) == 0 {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -125,7 +125,7 @@ func (c *Cluster) preScaleDown(newStatefulSet *v1beta1.StatefulSet) error {
 		return fmt.Errorf("pod %q does not belong to cluster", podName)
 	}
 
-	if err := c.patroni.Failover(&masterPod[0], masterCandidatePod.Name); err != nil {
+	if err := c.patroni.Switchover(&masterPod[0], masterCandidatePod.Name); err != nil {
 		return fmt.Errorf("could not failover: %v", err)
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -229,7 +229,7 @@ func (c *Cluster) syncStatefulSet() error {
 	var (
 		podsRollingUpdateRequired bool
 	)
-	// the following code should not return before the end of this function in a non-error case
+	// NB: Be careful to consider the codepath that acts on podsRollingUpdateRequired before returning early.
 	sset, err := c.KubeClient.StatefulSets(c.Namespace).Get(c.statefulSetName(), metav1.GetOptions{})
 	if err != nil {
 		if !k8sutil.ResourceNotFound(err) {
@@ -343,7 +343,8 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration() error {
 				c.logger.Warningf("could not patch postgres parameters with a pod %s: %v", podName, err)
 			}
 		}
-		return fmt.Errorf("could not call Patroni API to set Postgres options: failed on %d pods", len(pods))
+		return fmt.Errorf("could not reach Patroni API to set Postgres options: failed on every pod (%d total)",
+			len(pods))
 	}
 	return nil
 }

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 	policyv1beta1 "k8s.io/client-go/pkg/apis/policy/v1beta1"
 	"k8s.io/client-go/rest"
-	"os"
+
 )
 
 // EventType contains type of the events for the TPRs and Pods received from Kubernetes

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -21,7 +21,7 @@ const (
 
 // Interface describe patroni methods
 type Interface interface {
-	Failover(master *v1.Pod, candidate string) error
+	Switchover(master *v1.Pod, candidate string) error
 	SetPostgresParameters(server *v1.Pod, options map[string]string) error
 }
 
@@ -72,8 +72,8 @@ func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer)
 	return nil
 }
 
-// Failover does manual failover via Patroni POST API call
-func (p *Patroni) Failover(master *v1.Pod, candidate string) error {
+// Switchover by calling Patroni REST API
+func (p *Patroni) Switchover(master *v1.Pod, candidate string) error {
 	buf := &bytes.Buffer{}
 	err := json.NewEncoder(buf).Encode(map[string]string{"leader": master.Name, "member": candidate})
 	if err != nil {


### PR DESCRIPTION
Call Patroni API /config in order to set special options that are
ignored when set in the configuration file, such as max_connections.
Per https://github.com/zalando-incubator/postgres-operator/issues/297