### PR TITLE
Fix a crash on node migration.

### DIFF
--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -103,10 +103,10 @@ func (c *Cluster) resizeVolumes(newVolume spec.Volume, resizers []volumes.Volume
 
 	for _, pv := range pvs {
 		volumeSize := quantityToGigabyte(pv.Spec.Capacity[v1.ResourceStorage])
-		if volumeSize > newSize {
-			return fmt.Errorf("cannot shrink persistent volume")
-		}
-		if volumeSize == newSize {
+		if volumeSize >= newSize {
+			if volumeSize > newSize {
+				c.logger.Warningf("cannot shrink persistent volume")
+			}
 			continue
 		}
 		for _, resizer := range resizers {


### PR DESCRIPTION
After an unsuccessful initial cluster sync it may happen that the
cluster statefulset is empty. This has been made more likely since
88d6a7be3, since it has introduced syncing volumes before statefulsets,
and the volume sync may fail for different reasons (i.e. the volume has
been shrinked, or too many calls to Amazon).