### PR TITLE
Add patroni_use_kubernetes parameter.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -927,7 +927,7 @@ type ClusterObjectDelete func(name string) error
 
 func (c *Cluster) deletePatroniClusterObjects() error {
 	// TODO: figure out how to remove leftover patroni objects in other cases
-	if !c.patroniUsesKubernetes() {
+	if !c.OpConfig.PatroniUseKubernetes {
 		c.logger.Infof("not cleaning up Etcd Patroni objects on cluster delete")
 	}
 	c.logger.Debugf("removing leftover Patroni objects (endpoints or configmaps)")

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -399,7 +399,7 @@ func (c *Cluster) generatePodTemplate(
 		envVars = append(envVars, v1.EnvVar{Name: "LOG_BUCKET_SCOPE_PREFIX", Value: ""})
 	}
 
-	if c.patroniUsesKubernetes() {
+	if c.OpConfig.PatroniUseKubernetes {
 		envVars = append(envVars, v1.EnvVar{Name: "DCS_ENABLE_KUBERNETES_API", Value: "true"})
 	} else {
 		envVars = append(envVars, v1.EnvVar{Name: "ETCD_HOST", Value: c.OpConfig.EtcdHost})

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -460,7 +460,3 @@ func (c *Cluster) GetSpec() (*spec.Postgresql, error) {
 	defer c.specMu.RUnlock()
 	return cloneSpec(&c.Postgresql)
 }
-
-func (c *Cluster) patroniUsesKubernetes() bool {
-	return c.OpConfig.EtcdHost == ""
-}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -112,6 +112,7 @@ func (c *Controller) initOperatorConfig() {
 
 	c.opConfig = config.NewFromMap(configMapData)
 	c.warnOnDeprecatedOperatorParameters()
+	c.processDeprecatedOperatorParameters()
 
 	scalyrAPIKey := os.Getenv("SCALYR_API_KEY")
 	if scalyrAPIKey != "" {
@@ -125,6 +126,20 @@ func (c *Controller) warnOnDeprecatedOperatorParameters() {
 	if c.opConfig.EnableLoadBalancer != nil {
 		c.logger.Warningf("Operator configuration parameter 'enable_load_balancer' is deprecated and takes no effect. " +
 			"Consider using the 'enable_master_load_balancer' or 'enable_replica_load_balancer' instead.")
+	}
+	if c.opConfig.EtcdHost == "" && !c.opConfig.PatroniUseKubernetes {
+		c.logger.Warningf("Set 'patroni_use_kubernetes' instead of setting 'etcd_host' set to an empty string to enable " +
+			"support for Kubernetes API in Patroni.")
+	}
+	if c.opConfig.EtcdHost != "" && c.opConfig.PatroniUseKubernetes {
+		c.logger.Warningf("both 'patroni_use_kubernetes' is enabled and 'etcd_host' is set to a non-empty value, " +
+			"'patroni_use_kubernetes' is ignored.")
+	}
+}
+
+func (c *Controller) processDeprecatedOperatorParameters() {
+	if c.opConfig.EtcdHost == "" && !c.opConfig.PatroniUseKubernetes {
+		c.opConfig.PatroniUseKubernetes = true
 	}
 }
 

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 
 	WatchedNamespace     string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
 	EtcdHost             string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
-	PatroniUseKubernetes bool   `name:"patroni_use_kubernetes" default:"false"`
+	PatroniUseKubernetes bool   `name:"patroni_use_kubernetes" default:"true"`
 	DockerImage          string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
 	// default name `operator` enables backward compatibility with the older ServiceAccountName field
 	PodServiceAccountName string `name:"pod_service_account_name" default:"operator"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -68,9 +68,10 @@ type Config struct {
 	Auth
 	Scalyr
 
-	WatchedNamespace string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
-	EtcdHost         string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
-	DockerImage      string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
+	WatchedNamespace     string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
+	EtcdHost             string `name:"etcd_host" default:"etcd-client.default.svc.cluster.local:2379"`
+	PatroniUseKubernetes bool   `name:"patroni_use_kubernetes" default:"false"`
+	DockerImage          string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
 	// default name `operator` enables backward compatibility with the older ServiceAccountName field
 	PodServiceAccountName string `name:"pod_service_account_name" default:"operator"`
 	// value of this string must be valid JSON or YAML; see initPodServiceAccount


### PR DESCRIPTION
Add a dedicated parameter to enable support for Kubernetes in Patroni
instead of relying on a legacy hack of setting etcd_host to an empty
string. The latter still works, however, it will show a warning, nudging
users to change to the new parameter.

For the sake of not breaking existing non-Kubernetes setups,
patroni_use_kubernetes has not effect if etcd_host is set to a non-empty
value.