### PR TITLE
Bump up default Spilo image

### DIFF
--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 
 	WatchedNamespace string `name:"watched_namespace"`    // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
 	EtcdHost         string `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use k8s as a DCS
-	DockerImage      string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spiloprivate-9.6:1.2-p4"`
+	DockerImage      string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-cdp-10:1.4-p8"`
 	// default name `operator` enables backward compatibility with the older ServiceAccountName field
 	PodServiceAccountName string `name:"pod_service_account_name" default:"operator"`
 	// value of this string must be valid JSON or YAML; see initPodServiceAccount


### PR DESCRIPTION
Includes Patroni v1.4.4 that removes an issue with k8s v1.10+ API