### PR TITLE
Update travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+sudo: false
 
 branches:
   only:
@@ -7,7 +8,7 @@ branches:
 language: go
 
 go:
-  - 1.9
+  - "1.10.x"
 
 before_install:
   - go get github.com/Masterminds/glide


### PR DESCRIPTION
- explicitely set sudo to false, since we don't need it and it
  slows-down builds.
- use the newest go toolchain.