### PR TITLE
Improve generation of Scalyr container environment.

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -746,11 +746,11 @@ func generateScalyrSidecarSpec(clusterName, APIKey, serverURL, dockerImage strin
 	containerResources *spec.Resources, logger *logrus.Entry) *spec.Sidecar {
 	if APIKey == "" || dockerImage == "" {
 		if APIKey == "" && dockerImage != "" {
-			logger.Warningf("Not running Scalyr sidecar: SCALYR_API_KEY must be defined")
+			logger.Warning("Not running Scalyr sidecar: SCALYR_API_KEY must be defined")
 		}
 		return nil
 	}
-	spec := &spec.Sidecar{
+	scalarSpec := &spec.Sidecar{
 		Name:        "scalyr-sidecar",
 		DockerImage: dockerImage,
 		Env: []v1.EnvVar{
@@ -766,9 +766,9 @@ func generateScalyrSidecarSpec(clusterName, APIKey, serverURL, dockerImage strin
 		Resources: *containerResources,
 	}
 	if serverURL != "" {
-		spec.Env = append(spec.Env, v1.EnvVar{Name: "SCALYR_SERVER_URL", Value: serverURL})
+		scalarSpec.Env = append(scalarSpec.Env, v1.EnvVar{Name: "SCALYR_SERVER_URL", Value: serverURL})
 	}
-	return spec
+	return scalarSpec
 }
 
 // mergeSidecar merges globally-defined sidecars with those defined in the cluster manifest

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -744,35 +744,16 @@ func getEffectiveDockerImage(globalDockerImage, clusterDockerImage string) strin
 
 func generateScalyrSidecarSpec(clusterName, APIKey, serverURL, dockerImage string,
 	containerResources *spec.Resources, logger *logrus.Entry) *spec.Sidecar {
-	if APIKey == "" || serverURL == "" || dockerImage == "" {
-		if APIKey != "" || serverURL != "" || dockerImage != "" {
-			logger.Warningf("Incomplete configuration for the Scalyr sidecar: " +
-				"all of SCALYR_API_KEY, SCALYR_SERVER_HOST and SCALYR_SERVER_URL must be defined")
+	if APIKey == "" || dockerImage == "" {
+		if APIKey == "" && dockerImage != "" {
+			logger.Warningf("Not running Scalyr sidecar: SCALYR_API_KEY must be defined")
 		}
 		return nil
 	}
-	return &spec.Sidecar{
+	spec := &spec.Sidecar{
 		Name:        "scalyr-sidecar",
 		DockerImage: dockerImage,
 		Env: []v1.EnvVar{
-			{
-				Name: "POD_NAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
-						APIVersion: "v1",
-						FieldPath:  "metadata.name",
-					},
-				},
-			},
-			{
-				Name: "POD_NAMESPACE",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
-						APIVersion: "v1",
-						FieldPath:  "metadata.namespace",
-					},
-				},
-			},
 			{
 				Name:  "SCALYR_API_KEY",
 				Value: APIKey,
@@ -781,13 +762,13 @@ func generateScalyrSidecarSpec(clusterName, APIKey, serverURL, dockerImage strin
 				Name:  "SCALYR_SERVER_HOST",
 				Value: clusterName,
 			},
-			{
-				Name:  "SCALYR_SERVER_URL",
-				Value: serverURL,
-			},
 		},
 		Resources: *containerResources,
 	}
+	if serverURL != "" {
+		spec.Env = append(spec.Env, v1.EnvVar{Name: "SCALYR_SERVER_URL", Value: serverURL})
+	}
+	return spec
 }
 
 // mergeSidecar merges globally-defined sidecars with those defined in the cluster manifest


### PR DESCRIPTION
Avoid duplicating POD_NAME and POD_NAMESPACE that already bundled
every sidecar.

Do not complain on the lack of SCLALYR_SERVER_HOST, since it is set to
https://upload.eu.scalyr.com in the container we use.

Do not mentioned SCALYR_SERVER_HOST in the error messages, since it is
derived from the cluster name automatically.