### PR TITLE
Fix disabling database access and teams API via command-line options.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -114,10 +114,10 @@ func (c *Controller) modifyConfigFromEnvironment() {
 	c.opConfig.WatchedNamespace = c.getEffectiveNamespace(os.Getenv("WATCHED_NAMESPACE"), c.opConfig.WatchedNamespace)
 
 	if c.config.NoDatabaseAccess {
-		c.opConfig.EnableDBAccess = c.config.NoDatabaseAccess
+		c.opConfig.EnableDBAccess = false
 	}
 	if c.config.NoTeamsAPI {
-		c.opConfig.EnableTeamsAPI = c.config.NoTeamsAPI
+		c.opConfig.EnableTeamsAPI = false
 	}
 	scalyrAPIKey := os.Getenv("SCALYR_API_KEY")
 	if scalyrAPIKey != "" {


### PR DESCRIPTION
Interpretation of flags -nodatabaseacces and -noteamsapi was broken since 3a9378d3b8edef1789e062e1f446018b9f8e6528