### PR TITLE
linter-induced refactoring, next steps

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -157,7 +157,7 @@ func (s *Server) clusters(w http.ResponseWriter, req *http.Request) {
 	)
 
 	if matches := util.FindNamedStringSubmatch(clusterStatusURL, req.URL.Path); matches != nil {
-		namespace, _ := matches["namespace"]
+		namespace := matches["namespace"]
 		resp, err = s.controller.ClusterStatus(matches["team"], namespace, matches["cluster"])
 	} else if matches := util.FindNamedStringSubmatch(teamURL, req.URL.Path); matches != nil {
 		teamClusters := s.controller.TeamClusterList()
@@ -174,10 +174,10 @@ func (s *Server) clusters(w http.ResponseWriter, req *http.Request) {
 
 		resp, err = clusterNames, nil
 	} else if matches := util.FindNamedStringSubmatch(clusterLogsURL, req.URL.Path); matches != nil {
-		namespace, _ := matches["namespace"]
+		namespace := matches["namespace"]
 		resp, err = s.controller.ClusterLogs(matches["team"], namespace, matches["cluster"])
 	} else if matches := util.FindNamedStringSubmatch(clusterHistoryURL, req.URL.Path); matches != nil {
-		namespace, _ := matches["namespace"]
+		namespace := matches["namespace"]
 		resp, err = s.controller.ClusterHistory(matches["team"], namespace, matches["cluster"])
 	} else if req.URL.Path == clustersURL {
 		clusterNamesPerTeam := make(map[string][]string)
@@ -194,8 +194,8 @@ func (s *Server) clusters(w http.ResponseWriter, req *http.Request) {
 	s.respond(resp, err, w)
 }
 
-func mustConvertToUint32(s string) uint32{
-	result, err := strconv.Atoi(s);
+func mustConvertToUint32(s string) uint32 {
+	result, err := strconv.Atoi(s)
 	if err != nil {
 		panic(fmt.Errorf("mustConvertToUint32 called for %s: %v", s, err))
 	}
@@ -244,8 +244,6 @@ func (s *Server) databases(w http.ResponseWriter, req *http.Request) {
 
 	databaseNamesPerCluster := s.controller.ClusterDatabasesMap()
 	s.respond(databaseNamesPerCluster, nil, w)
-	return
-
 }
 
 func (s *Server) allQueues(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -183,8 +183,8 @@ func (c *Cluster) masterCandidate(oldNodeName string) (*v1.Pod, error) {
 func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 	var (
 		masterCandidatePod *v1.Pod
-		err error
-		eol bool
+		err                error
+		eol                bool
 	)
 
 	oldMaster, err := c.KubeClient.Pods(podName.Namespace).Get(podName.Name, metav1.GetOptions{})
@@ -212,7 +212,7 @@ func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 		var sset *v1beta1.StatefulSet
 		if sset, err = c.KubeClient.StatefulSets(c.Namespace).Get(c.statefulSetName(),
 			metav1.GetOptions{}); err != nil {
-				return fmt.Errorf("could not retrieve cluster statefulset: %v", err)
+			return fmt.Errorf("could not retrieve cluster statefulset: %v", err)
 		}
 		c.Statefulset = sset
 	}
@@ -224,7 +224,6 @@ func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 	} else {
 		c.logger.Warningf("single master pod for cluster %q, migration will cause longer downtime of the master instance", c.clusterName())
 	}
-
 
 	// there are two cases for each postgres cluster that has its master pod on the node to migrate from:
 	// - the cluster has some replicas - migrate one of those if necessary and failover to it

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -633,27 +633,3 @@ func (c *Cluster) GetStatefulSet() *v1beta1.StatefulSet {
 func (c *Cluster) GetPodDisruptionBudget() *policybeta1.PodDisruptionBudget {
 	return c.PodDisruptionBudget
 }
-
-func (c *Cluster) createDatabases() error {
-	c.setProcessName("creating databases")
-
-	if len(c.Spec.Databases) == 0 {
-		return nil
-	}
-
-	if err := c.initDbConn(); err != nil {
-		return fmt.Errorf("could not init database connection")
-	}
-	defer func() {
-		if err := c.closeDbConn(); err != nil {
-			c.logger.Errorf("could not close database connection: %v", err)
-		}
-	}()
-
-	for datname, owner := range c.Spec.Databases {
-		if err := c.executeCreateDatabase(datname, owner); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) initPodServiceAccount() {
 func (c *Controller) initRoleBinding() {
 
 	// service account on its own lacks any rights starting with k8s v1.8
-	// operator binds it to the cluster role with sufficient priviliges
+	// operator binds it to the cluster role with sufficient privileges
 	// we assume the role is created by the k8s administrator
 	if c.opConfig.PodServiceAccountRoleBindingDefinition == "" {
 		c.opConfig.PodServiceAccountRoleBindingDefinition = `
@@ -199,9 +199,9 @@ func (c *Controller) initRoleBinding() {
 
 	switch {
 	case err != nil:
-		panic(fmt.Errorf("Unable to parse the definiton of the role binding  for the pod service account definiton from the operator config map: %v", err))
+		panic(fmt.Errorf("Unable to parse the definition of the role binding for the pod service account definition from the operator config map: %v", err))
 	case groupVersionKind.Kind != "RoleBinding":
-		panic(fmt.Errorf("role binding definiton in the operator config map defines another type of resource: %v", groupVersionKind.Kind))
+		panic(fmt.Errorf("role binding definition in the operator config map defines another type of resource: %v", groupVersionKind.Kind))
 	default:
 		c.PodServiceAccountRoleBinding = obj.(*rbacv1beta1.RoleBinding)
 		c.PodServiceAccountRoleBinding.Namespace = ""

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -130,7 +131,9 @@ type crdDecoder struct {
 }
 
 func (d *crdDecoder) Close() {
-	d.close()
+	if err := d.close(); err != nil {
+		fmt.Printf("error when closing CRDDecorer: %v\n", err)
+	}
 }
 
 func (d *crdDecoder) Decode() (action watch.EventType, object runtime.Object, err error) {
@@ -526,7 +529,6 @@ func (c *Controller) submitRBACCredentials(event spec.ClusterEvent) error {
 	if err := c.createRoleBindings(namespace); err != nil {
 		return fmt.Errorf("could not create role binding %v : %v", c.PodServiceAccountRoleBinding.Name, err)
 	}
-
 	c.namespacesWithDefinedRBAC.Store(namespace, true)
 	return nil
 }

--- a/pkg/spec/postgresql.go
+++ b/pkg/spec/postgresql.go
@@ -156,7 +156,9 @@ var (
 // will not contain any private fields not-reachable to deepcopy. This should be ok,
 // since Error is never read from a Kubernetes object.
 func (p *Postgresql) Clone() *Postgresql {
-	if p == nil {return nil}
+	if p == nil {
+		return nil
+	}
 	c := deepcopy.Copy(p).(*Postgresql)
 	c.Error = nil
 	return c
@@ -166,11 +168,12 @@ func (p *Postgresql) DeepCopyInto(out *Postgresql) {
 	if p != nil {
 		*out = deepcopy.Copy(*p).(Postgresql)
 	}
-	return
 }
 
 func (p *Postgresql) DeepCopy() *Postgresql {
-	if p == nil { return nil }
+	if p == nil {
+		return nil
+	}
 	out := new(Postgresql)
 	p.DeepCopyInto(out)
 	return out
@@ -308,7 +311,6 @@ func validateCloneClusterDescription(clone *CloneDescription) error {
 type postgresqlListCopy PostgresqlList
 type postgresqlCopy Postgresql
 
-
 // UnmarshalJSON converts a JSON into the PostgreSQL object.
 func (p *Postgresql) UnmarshalJSON(data []byte) error {
 	var tmp postgresqlCopy
@@ -359,7 +361,9 @@ func (pl *PostgresqlList) UnmarshalJSON(data []byte) error {
 }
 
 func (pl *PostgresqlList) DeepCopy() *PostgresqlList {
-	if pl == nil { return nil }
+	if pl == nil {
+		return nil
+	}
 	out := new(PostgresqlList)
 	pl.DeepCopyInto(out)
 	return out
@@ -369,7 +373,6 @@ func (pl *PostgresqlList) DeepCopyInto(out *PostgresqlList) {
 	if pl != nil {
 		*out = deepcopy.Copy(*pl).(PostgresqlList)
 	}
-	return
 }
 
 func (pl *PostgresqlList) DeepCopyObject() runtime.Object {
@@ -378,7 +381,6 @@ func (pl *PostgresqlList) DeepCopyObject() runtime.Object {
 	}
 	return nil
 }
-
 
 func (status PostgresStatus) Success() bool {
 	return status != ClusterStatusAddFailed &&

--- a/pkg/util/config/crd_config.go
+++ b/pkg/util/config/crd_config.go
@@ -3,11 +3,11 @@ package config
 import (
 	"encoding/json"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/zalando-incubator/postgres-operator/pkg/spec"
-	"github.com/mohae/deepcopy"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/mohae/deepcopy"
 )
 
 type OperatorConfiguration struct {
@@ -159,11 +159,12 @@ func (opc *OperatorConfiguration) DeepCopyInto(out *OperatorConfiguration) {
 	if opc != nil {
 		*out = deepcopy.Copy(*opc).(OperatorConfiguration)
 	}
-	return
 }
 
 func (opc *OperatorConfiguration) DeepCopy() *OperatorConfiguration {
-	if opc == nil { return nil }
+	if opc == nil {
+		return nil
+	}
 	out := new(OperatorConfiguration)
 	opc.DeepCopyInto(out)
 	return out
@@ -189,11 +190,12 @@ func (opcl *OperatorConfigurationList) DeepCopyInto(out *OperatorConfigurationLi
 	if opcl != nil {
 		*out = deepcopy.Copy(*opcl).(OperatorConfigurationList)
 	}
-	return
 }
 
 func (opcl *OperatorConfigurationList) DeepCopy() *OperatorConfigurationList {
-	if opcl == nil { return nil }
+	if opcl == nil {
+		return nil
+	}
 	out := new(OperatorConfigurationList)
 	opcl.DeepCopyInto(out)
 	return out
@@ -205,4 +207,3 @@ func (opcl *OperatorConfigurationList) DeepCopyObject() runtime.Object {
 	}
 	return nil
 }
-

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -47,7 +47,7 @@ func apiURL(masterPod *v1.Pod) string {
 	return fmt.Sprintf("http://%s:%d", masterPod.Status.PodIP, apiPort)
 }
 
-func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer) error {
+func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer) (err error) {
 	request, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return fmt.Errorf("could not create request: %v", err)
@@ -59,7 +59,16 @@ func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer)
 	if err != nil {
 		return fmt.Errorf("could not make request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err2 := resp.Body.Close(); err2 != nil {
+			if err != nil {
+				err = fmt.Errorf("could not close request: %v, prior error: %v", err2, err)
+			} else {
+				err = fmt.Errorf("could not close request: %v", err2)
+			}
+			return
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
@@ -83,6 +92,7 @@ func (p *Patroni) Switchover(master *v1.Pod, candidate string) error {
 }
 
 //TODO: add an option call /patroni to check if it is necessary to restart the server
+
 //SetPostgresParameters sets Postgres options via Patroni patch API call.
 func (p *Patroni) SetPostgresParameters(server *v1.Pod, parameters map[string]string) error {
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
Linter-induced code refactoring, run round 2.

Run more linters in the gometalinter, i.e. deadcode, megacheck,
nakedret, dup.

More consistent code formatting, remove two dead functions, eliminate
naked a bunch of naked returns, refactor a few functions to avoid code
duplication.