### PR TITLE
Populate list of clusters in the controller at startup.

### DIFF
--- a/pkg/util/config/util.go
+++ b/pkg/util/config/util.go
@@ -172,10 +172,9 @@ func processField(value string, field reflect.Value) error {
 type parserState int
 
 const (
-	Plain parserState = iota
-	DoubleQuoted
-	SingleQuoted
-	Escape
+	plain        parserState = iota
+	doubleQuoted
+	singleQuoted
 )
 
 // Split the pair candidates by commas not located inside open quotes
@@ -183,7 +182,7 @@ const (
 // expect to find them inside the map values for our use cases
 func getMapPairsFromString(value string) (pairs []string, err error) {
 	pairs = make([]string, 0)
-	state := Plain
+	state := plain
 	var start, quote int
 
 	for i, ch := range strings.Split(value, "") {
@@ -191,29 +190,29 @@ func getMapPairsFromString(value string) (pairs []string, err error) {
 			fmt.Printf("Parser warning: ecape character '\\' have no effect on quotes inside the configuration value %s\n", value)
 		}
 		if ch == `"` {
-			if state == Plain {
-				state = DoubleQuoted
+			if state == plain {
+				state = doubleQuoted
 				quote = i
-			} else if state == DoubleQuoted {
-				state = Plain
+			} else if state == doubleQuoted {
+				state = plain
 				quote = 0
 			}
 		}
 		if ch == "'" {
-			if state == Plain {
-				state = SingleQuoted
+			if state == plain {
+				state = singleQuoted
 				quote = i
-			} else if state == SingleQuoted {
-				state = Plain
+			} else if state == singleQuoted {
+				state = plain
 				quote = 0
 			}
 		}
-		if ch == "," && state == Plain {
+		if ch == "," && state == plain {
 			pairs = append(pairs, strings.Trim(value[start:i], " \t"))
 			start = i + 1
 		}
 	}
-	if state != Plain {
+	if state != plain {
 		err = fmt.Errorf("unmatched quote starting at position %d", quote+1)
 		pairs = nil
 	} else {


### PR DESCRIPTION
Assign the list of clusters in the controller with the up-to-date list
of Postgres manifests on Kubernetes during the startup.

Node migration routines launched asynchronously to the cluster
processing rely on an up-to-date list of clusters in the controller to
detect clusters affected by the migration of the node and lock them
when doing migration of master pods. Without the initial list the
operator was subject to race conditions like the one described at
https://github.com/zalando-incubator/postgres-operator/issues/363

Restructure the code to decouple list cluster function required by the
postgresql informer from the one that emits cluster sync events. No
extra work is introduced, since cluster sync already runs in a separate
goroutine (clusterResync).

Introduce explicit initial cluster sync at the end of
acquireInitialListOfClusters instead of relying on an implicit one
coming from list function of the PostgreSQL informer.

Some minor refactoring.