### PR TITLE
Some tweaks to ensure compat with newer Go

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/util_test.go
+++ b/pkg/apis/acid.zalan.do/v1/util_test.go
@@ -129,13 +129,8 @@ var unmarshalCluster = []struct {
 			Name: "acid-testcluster1",
 		},
 		Status: ClusterStatusInvalid,
-		Error: (&json.UnmarshalTypeError{
-			Value:  "number",
-			Type:   reflect.TypeOf(""),
-			Offset: 126,
-			Struct: "PostgresSpec",
-			Field:  "teamId",
-		}).Error(),
+		// This error message can vary between Go versions, so compute it for the current version.
+		Error: json.Unmarshal([]byte(`{"teamId": 0}`), &PostgresSpec{}).Error(),
 	},
 	[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`), nil},
 	{[]byte(`{

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -256,7 +256,7 @@ func TestInitHumanUsersWithSuperuserTeams(t *testing.T) {
 			ownerTeam: "postgres_superusers",
 			existingRoles: map[string]spec.PgUser{
 				// role with the name exists before  w/o superuser privilege
-				"postgres_superuser": spec.PgUser{
+				"postgres_superuser": {
 					Origin:     spec.RoleOriginTeamsAPI,
 					Name:       "postgres_superuser",
 					Password:   "",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -139,10 +139,10 @@ func (c *Controller) initPodServiceAccount() {
 
 	if c.opConfig.PodServiceAccountDefinition == "" {
 		c.opConfig.PodServiceAccountDefinition = `
-		{ "apiVersion": "v1", 
-		  "kind": "ServiceAccount", 
-		  "metadata": { 
-				 "name": "operator" 
+		{ "apiVersion": "v1",
+		  "kind": "ServiceAccount",
+		  "metadata": {
+				 "name": "operator"
 		   }
 		}`
 	}
@@ -175,10 +175,10 @@ func (c *Controller) initRoleBinding() {
 	// we assume the role is created by the k8s administrator
 	if c.opConfig.PodServiceAccountRoleBindingDefinition == "" {
 		c.opConfig.PodServiceAccountRoleBindingDefinition = `
-		{ 
+		{
 			"apiVersion": "rbac.authorization.k8s.io/v1beta1",
-			"kind": "RoleBinding", 
-			"metadata": { 
+			"kind": "RoleBinding",
+			"metadata": {
 				   "name": "zalando-postgres-operator"
 			},
 			"roleRef": {
@@ -191,7 +191,7 @@ func (c *Controller) initRoleBinding() {
 					"kind": "ServiceAccount",
 					"name": "operator"
 				}
-			]	
+			]
 		}`
 	}
 	c.logger.Info("Parse role bindings")

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -71,7 +71,7 @@ func (c *Controller) clusterListAndSync() error {
 		}
 		c.queueEvents(list, event)
 	} else {
-		c.logger.Infof("not enough time passed since the last sync (%s seconds) or repair (%s seconds)",
+		c.logger.Infof("not enough time passed since the last sync (%v seconds) or repair (%v seconds)",
 			timeFromPreviousSync, timeFromPreviousRepair)
 	}
 	return nil


### PR DESCRIPTION
I upgraded to 1.11 on my laptop and thought I would clean up some minor things. Newer gofmt, a tweak to a format string to please newer `vet`, and fixing one test where the error message appears to vary between Go versions.