### PR TITLE
API url regexps

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -48,11 +48,22 @@ type Server struct {
 	controller controllerInformer
 }
 
+const (
+	teamRe      = `(?P<team>[a-zA-Z][a-zA-Z0-9\-_]*)`
+	namespaceRe = `(?P<namespace>[a-z0-9]([-a-z0-9\-_]*[a-z0-9])?)`
+	clusterRe   = `(?P<cluster>[a-zA-Z][a-zA-Z0-9\-_]*)`
+)
+
 var (
-	clusterStatusURL     = regexp.MustCompile(`^/clusters/(?P<team>[a-zA-Z][a-zA-Z0-9]*)/(?P<namespace>[a-z0-9]([-a-z0-9]*[a-z0-9])?)/(?P<cluster>[a-zA-Z][a-zA-Z0-9-]*)/?$`)
-	clusterLogsURL       = regexp.MustCompile(`^/clusters/(?P<team>[a-zA-Z][a-zA-Z0-9]*)/(?P<namespace>[a-z0-9]([-a-z0-9]*[a-z0-9])?)/(?P<cluster>[a-zA-Z][a-zA-Z0-9-]*)/logs/?$`)
-	clusterHistoryURL    = regexp.MustCompile(`^/clusters/(?P<team>[a-zA-Z][a-zA-Z0-9]*)/(?P<namespace>[a-z0-9]([-a-z0-9]*[a-z0-9])?)/(?P<cluster>[a-zA-Z][a-zA-Z0-9-]*)/history/?$`)
-	teamURL              = regexp.MustCompile(`^/clusters/(?P<team>[a-zA-Z][a-zA-Z0-9]*)/?$`)
+	clusterStatusRe  = fmt.Sprintf(`^/clusters/%s/%s/%s/?$`, teamRe, namespaceRe, clusterRe)
+	clusterLogsRe    = fmt.Sprintf(`^/clusters/%s/%s/%s/logs/?$`, teamRe, namespaceRe, clusterRe)
+	clusterHistoryRe = fmt.Sprintf(`^/clusters/%s/%s/%s/history/?$`, teamRe, namespaceRe, clusterRe)
+	teamURLRe        = fmt.Sprintf(`^/clusters/%s/?$`, teamRe)
+
+	clusterStatusURL     = regexp.MustCompile(clusterStatusRe)
+	clusterLogsURL       = regexp.MustCompile(clusterLogsRe)
+	clusterHistoryURL    = regexp.MustCompile(clusterHistoryRe)
+	teamURL              = regexp.MustCompile(teamURLRe)
 	workerLogsURL        = regexp.MustCompile(`^/workers/(?P<id>\d+)/logs/?$`)
 	workerEventsQueueURL = regexp.MustCompile(`^/workers/(?P<id>\d+)/queue/?$`)
 	workerStatusURL      = regexp.MustCompile(`^/workers/(?P<id>\d+)/status/?$`)

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -5,14 +5,19 @@ import (
 )
 
 const (
-	clusterStatusTest = "/clusters/test-id/test_namespace/testcluster/"
-	clusterLogsTest   = "/clusters/test-id/test_namespace/testcluster/logs/"
-	teamTest          = "/clusters/test-id/"
+	clusterStatusTest        = "/clusters/test-id/test_namespace/testcluster/"
+	clusterStatusNumericTest = "/clusters/test-id-1/test_namespace/testcluster/"
+	clusterLogsTest          = "/clusters/test-id/test_namespace/testcluster/logs/"
+	teamTest                 = "/clusters/test-id/"
 )
 
 func TestUrlRegexps(t *testing.T) {
 	if clusterStatusURL.FindStringSubmatch(clusterStatusTest) == nil {
 		t.Errorf("clusterStatusURL can't match %s", clusterStatusTest)
+	}
+
+	if clusterStatusURL.FindStringSubmatch(clusterStatusNumericTest) == nil {
+		t.Errorf("clusterStatusURL can't match %s", clusterStatusNumericTest)
 	}
 
 	if clusterLogsURL.FindStringSubmatch(clusterLogsTest) == nil {

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -1,0 +1,25 @@
+package apiserver
+
+import (
+	"testing"
+)
+
+const (
+	clusterStatusTest = "/clusters/test-id/test_namespace/testcluster/"
+	clusterLogsTest   = "/clusters/test-id/test_namespace/testcluster/logs/"
+	teamTest          = "/clusters/test-id/"
+)
+
+func TestUrlRegexps(t *testing.T) {
+	if clusterStatusURL.FindStringSubmatch(clusterStatusTest) == nil {
+		t.Errorf("clusterStatusURL can't match %s", clusterStatusTest)
+	}
+
+	if clusterLogsURL.FindStringSubmatch(clusterLogsTest) == nil {
+		t.Errorf("clusterLogsURL can't match %s", clusterLogsTest)
+	}
+
+	if teamURL.FindStringSubmatch(teamTest) == nil {
+		t.Errorf("teamURL can't match %s", teamTest)
+	}
+}


### PR DESCRIPTION
Make regexps for API more flexible, to allow e.g. teamId contains dashes. Solves #394 