### PR TITLE
Restore .zappr.yaml

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,0 +1,12 @@
+# for github.com
+approvals:
+  groups:
+    zalando:
+      minimum: 2
+      from:
+        orgs:
+          - "zalando"
+X-Zalando-Team: "acid"
+# type should be one of [code, doc, config, tools, secrets]
+# code will be the default value, if X-Zalando-Type is not found in .zappr.yml
+X-Zalando-Type: code

--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,11 +1,4 @@
 # for github.com
-approvals:
-  groups:
-    zalando:
-      minimum: 2
-      from:
-        orgs:
-          - "zalando"
 X-Zalando-Team: "acid"
 # type should be one of [code, doc, config, tools, secrets]
 # code will be the default value, if X-Zalando-Type is not found in .zappr.yml


### PR DESCRIPTION
Despite no longer being used for PR approvals, it is still needed for CDP web hooks to function correctly.