### PR TITLE
Fix reference to enable_database_access in operator_parameters.md

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -334,7 +334,7 @@ Options to aid debugging of the operator itself. Grouped under the `debug` key.
   boolean parameter that toggles verbose debug logs from the operator. The
   default is `true`.
 
-* **enable_db_access**
+* **enable_database_access**
   boolean parameter that toggles the functionality of the operator that require
   access to the postgres database, i.e. creating databases and users. The default
   is `true`.


### PR DESCRIPTION
AFAICT the parameter `enable_db_access` referred to in docs/reference/operator_parameters.md should really be `enable_database_access`.