### PR TITLE
Modifying some of the logging to be more descriptive.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	policybeta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -877,7 +877,7 @@ func (c *Cluster) GetStatus() *ClusterStatus {
 func (c *Cluster) Switchover(curMaster *v1.Pod, candidate spec.NamespacedName) error {
 
 	var err error
-	c.logger.Debugf("failing over from %q to %q", curMaster.Name, candidate)
+	c.logger.Debugf("switching over from %q to %q", curMaster.Name, candidate)
 
 	var wg sync.WaitGroup
 
@@ -903,12 +903,12 @@ func (c *Cluster) Switchover(curMaster *v1.Pod, candidate spec.NamespacedName) e
 	}()
 
 	if err = c.patroni.Switchover(curMaster, candidate.Name); err == nil {
-		c.logger.Debugf("successfully failed over from %q to %q", curMaster.Name, candidate)
+		c.logger.Debugf("successfully switched over from %q to %q", curMaster.Name, candidate)
 		if err = <-podLabelErr; err != nil {
 			err = fmt.Errorf("could not get master pod label: %v", err)
 		}
 	} else {
-		err = fmt.Errorf("could not failover: %v", err)
+		err = fmt.Errorf("could not switch over: %v", err)
 	}
 
 	// signal the role label waiting goroutine to close the shop and go home

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/zalando-incubator/postgres-operator/pkg/spec"
@@ -122,7 +122,7 @@ func (c *Cluster) movePodFromEndOfLifeNode(pod *v1.Pod) (*v1.Pod, error) {
 	if eol, err = c.podIsEndOfLife(pod); err != nil {
 		return nil, fmt.Errorf("could not get node %q: %v", pod.Spec.NodeName, err)
 	} else if !eol {
-		c.logger.Infof("pod %q is already on a live node", podName)
+		c.logger.Infof("check failed: pod %q is already on a live node", podName)
 		return pod, nil
 	}
 
@@ -162,7 +162,7 @@ func (c *Cluster) masterCandidate(oldNodeName string) (*v1.Pod, error) {
 	}
 
 	if len(replicas) == 0 {
-		c.logger.Warningf("no available master candidates, migration will cause longer downtime of the master instance")
+		c.logger.Warningf("no available master candidates, migration will cause longer downtime of Postgres cluster")
 		return nil, nil
 	}
 
@@ -193,18 +193,18 @@ func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 		return fmt.Errorf("could not get pod: %v", err)
 	}
 
-	c.logger.Infof("migrating master pod %q", podName)
+	c.logger.Infof("starting process to migrate master pod %q", podName)
 
 	if eol, err = c.podIsEndOfLife(oldMaster); err != nil {
 		return fmt.Errorf("could not get node %q: %v", oldMaster.Spec.NodeName, err)
 	}
 	if !eol {
-		c.logger.Debugf("pod is already on a live node")
+		c.logger.Debugf("no action needed: master pod is already on a live node")
 		return nil
 	}
 
 	if role := PostgresRole(oldMaster.Labels[c.OpConfig.PodRoleLabel]); role != Master {
-		c.logger.Warningf("pod %q is not a master", podName)
+		c.logger.Warningf("no action needed: pod %q is not the master (anymore)", podName)
 		return nil
 	}
 	// we must have a statefulset in the cluster for the migration to work
@@ -219,10 +219,10 @@ func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 	// We may not have a cached statefulset if the initial cluster sync has aborted, revert to the spec in that case.
 	if *c.Statefulset.Spec.Replicas > 1 {
 		if masterCandidatePod, err = c.masterCandidate(oldMaster.Spec.NodeName); err != nil {
-			return fmt.Errorf("could not get new master candidate: %v", err)
+			return fmt.Errorf("could not suitable replica candidate for failover: %v", err)
 		}
 	} else {
-		c.logger.Warningf("single master pod for cluster %q, migration will cause longer downtime of the master instance", c.clusterName())
+		c.logger.Warningf("Migrating single pod cluster %q, migration will cause longer downtime of the postgres cluster until rescheduled", c.clusterName())
 	}
 
 	// there are two cases for each postgres cluster that has its master pod on the node to migrate from:
@@ -256,15 +256,15 @@ func (c *Cluster) MigrateReplicaPod(podName spec.NamespacedName, fromNodeName st
 		return fmt.Errorf("could not get pod: %v", err)
 	}
 
-	c.logger.Infof("migrating replica pod %q", podName)
+	c.logger.Infof("migrating replica pod %q to live node", podName)
 
 	if replicaPod.Spec.NodeName != fromNodeName {
-		c.logger.Infof("pod %q has already migrated to node %q", podName, replicaPod.Spec.NodeName)
+		c.logger.Infof("check failed: pod %q has already migrated to node %q", podName, replicaPod.Spec.NodeName)
 		return nil
 	}
 
 	if role := PostgresRole(replicaPod.Labels[c.OpConfig.PodRoleLabel]); role != Replica {
-		return fmt.Errorf("pod %q is not a replica", podName)
+		return fmt.Errorf("check failed: pod %q is not a replica", podName)
 	}
 
 	_, err = c.movePodFromEndOfLifeNode(replicaPod)
@@ -296,7 +296,7 @@ func (c *Cluster) recreatePod(podName spec.NamespacedName) (*v1.Pod, error) {
 }
 
 func (c *Cluster) recreatePods() error {
-	c.setProcessName("recreating pods")
+	c.setProcessName("starting to recreate pods")
 	ls := c.labelsSet(false)
 	namespace := c.Namespace
 
@@ -337,10 +337,10 @@ func (c *Cluster) recreatePods() error {
 		// failover if we have not observed a master pod when re-creating former replicas.
 		if newMasterPod == nil && len(replicas) > 0 {
 			if err := c.Switchover(masterPod, masterCandidate(replicas)); err != nil {
-				c.logger.Warningf("could not perform failover: %v", err)
+				c.logger.Warningf("could not perform switch over: %v", err)
 			}
 		} else if newMasterPod == nil && len(replicas) == 0 {
-			c.logger.Warningf("cannot switch master role before re-creating the pod: no replicas")
+			c.logger.Warningf("cannot perform switch over before re-creating the pod: no replicas")
 		}
 		c.logger.Infof("recreating old master pod %q", util.NameFromMeta(masterPod.ObjectMeta))
 

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -219,10 +219,10 @@ func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 	// We may not have a cached statefulset if the initial cluster sync has aborted, revert to the spec in that case.
 	if *c.Statefulset.Spec.Replicas > 1 {
 		if masterCandidatePod, err = c.masterCandidate(oldMaster.Spec.NodeName); err != nil {
-			return fmt.Errorf("could not suitable replica candidate for failover: %v", err)
+			return fmt.Errorf("could not find suitable replica pod as candidate for failover: %v", err)
 		}
 	} else {
-		c.logger.Warningf("migrating single pod cluster %q, migration will cause longer downtime of the postgres cluster until rescheduled", c.clusterName())
+		c.logger.Warningf("migrating single pod cluster %q, this will cause downtime of the Postgres cluster until pod is back", c.clusterName())
 	}
 
 	// there are two cases for each postgres cluster that has its master pod on the node to migrate from:

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -222,7 +222,7 @@ func (c *Cluster) MigrateMasterPod(podName spec.NamespacedName) error {
 			return fmt.Errorf("could not suitable replica candidate for failover: %v", err)
 		}
 	} else {
-		c.logger.Warningf("Migrating single pod cluster %q, migration will cause longer downtime of the postgres cluster until rescheduled", c.clusterName())
+		c.logger.Warningf("migrating single pod cluster %q, migration will cause longer downtime of the postgres cluster until rescheduled", c.clusterName())
 	}
 
 	// there are two cases for each postgres cluster that has its master pod on the node to migrate from:


### PR DESCRIPTION
Diving into the migration failures we see that the logging is in parts confusing and not splitting "steps/process" messages from the action messages.