### PR TITLE
Report new Postgres CR error when previously incorrect one is being updated

### DIFF
--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -385,8 +385,14 @@ func (c *Controller) queueClusterEvent(informerOldSpec, informerNewSpec *acidv1.
 	if informerOldSpec != nil { //update, delete
 		uid = informerOldSpec.GetUID()
 		clusterName = util.NameFromMeta(informerOldSpec.ObjectMeta)
+
+		// user is fixing previously incorrect spec
 		if eventType == EventUpdate && informerNewSpec.Error == "" && informerOldSpec.Error != "" {
 			eventType = EventSync
+		}
+
+		// set current error to be one of the new spec if present
+		if informerNewSpec != nil {
 			clusterError = informerNewSpec.Error
 		} else {
 			clusterError = informerOldSpec.Error


### PR DESCRIPTION
This fixes https://github.com/zalando-incubator/postgres-operator/issues/448

After this patch creating a Postgres resource with missing teamId and then updating it with incorrect teamId, it  reports new error as expected:

```
infra-postgres-operator-dev-7658595fb-mjjvw main time="2019-01-10T15:19:26Z" level=debug msg="skipping \"ADD\" event for the invalid cluster: team name is empty" cluster-name=dev/acid-test-cluster pkg=controller
infra-postgres-operator-dev-7658595fb-mjjvw main time="2019-01-10T15:19:46Z" level=debug msg="skipping \"UPDATE\" event for the invalid cluster: name must match {TEAM}-{NAME} format" cluster-name=dev/acid-test-cluster pkg=controller
```