### PR TITLE
Added possibility to add custom annotations to LoadBalancer service.

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -294,6 +294,11 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   cluster.  Can be overridden by individual cluster settings. The default is
   `false`.
 
+* **custom_service_annotations**
+  when load balancing is enabled, LoadBalancer service is created and
+  this parameter takes service annotations that are applied to service.
+  Optional.
+
 * **master_dns_name_format** defines the DNS name string template for the
   master load balancer cluster.  The default is
   `{cluster}.{team}.{hostedzone}`, where `{cluster}` is replaced by the cluster

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -15,6 +15,8 @@ data:
   secret_name_template: '{username}.{cluster}.credentials'
   super_username: postgres
   enable_teams_api: "false"
+  # custom_service_annotations:
+  #   "keyx:valuez,keya:valuea"
   # set_memory_request_to_limit: "true"
   # postgres_superuser_teams: "postgres_superusers"
   # enable_team_superuser: "false"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -46,6 +46,9 @@ configuration:
   load_balancer:
     enable_master_load_balancer: false
     enable_replica_load_balancer: false
+    # custom_service_annotations:
+    #   keyx: valuex
+    #   keyy: valuey
     master_dns_name_format: "{cluster}.{team}.{hostedzone}"
     replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
   aws_or_gcp:

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -84,6 +84,7 @@ type LoadBalancerConfiguration struct {
 	DbHostedZone              string                `json:"db_hosted_zone,omitempty"`
 	EnableMasterLoadBalancer  bool                  `json:"enable_master_load_balancer,omitempty"`
 	EnableReplicaLoadBalancer bool                  `json:"enable_replica_load_balancer,omitempty"`
+	CustomServiceAnnotations  map[string]string     `json:"custom_service_annotations,omitempty"`
 	MasterDNSNameFormat       config.StringTemplate `json:"master_dns_name_format,omitempty"`
 	ReplicaDNSNameFormat      config.StringTemplate `json:"replica_dns_name_format,omitempty"`
 }

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1093,6 +1093,13 @@ func (c *Cluster) generateService(role PostgresRole, spec *acidv1.PostgresSpec) 
 			constants.ZalandoDNSNameAnnotation: dnsName,
 			constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
 		}
+
+		if len(c.OpConfig.CustomServiceAnnotations) != 0 {
+			c.logger.Debugf("There are custom annotations defined, creating them.")
+			for customAnnotationKey, customAnnotationValue := range c.OpConfig.CustomServiceAnnotations {
+				annotations[customAnnotationKey] = customAnnotationValue
+			}
+		}
 	} else if role == Replica {
 		// before PR #258, the replica service was only created if allocated a LB
 		// now we always create the service but warn if the LB is absent

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -67,6 +67,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.DbHostedZone = fromCRD.LoadBalancer.DbHostedZone
 	result.EnableMasterLoadBalancer = fromCRD.LoadBalancer.EnableMasterLoadBalancer
 	result.EnableReplicaLoadBalancer = fromCRD.LoadBalancer.EnableReplicaLoadBalancer
+	result.CustomServiceAnnotations = fromCRD.LoadBalancer.CustomServiceAnnotations
 	result.MasterDNSNameFormat = fromCRD.LoadBalancer.MasterDNSNameFormat
 	result.ReplicaDNSNameFormat = fromCRD.LoadBalancer.ReplicaDNSNameFormat
 

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -93,6 +93,7 @@ type Config struct {
 	EnableAdminRoleForUsers                bool   `name:"enable_admin_role_for_users" default:"true"`
 	EnableMasterLoadBalancer               bool   `name:"enable_master_load_balancer" default:"true"`
 	EnableReplicaLoadBalancer              bool   `name:"enable_replica_load_balancer" default:"false"`
+	CustomServiceAnnotations			   map[string]string `name:"custom_service_annotations"`
 	// deprecated and kept for backward compatibility
 	EnableLoadBalancer       *bool             `name:"enable_load_balancer"`
 	MasterDNSNameFormat      StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`

--- a/run_operator_locally.sh
+++ b/run_operator_locally.sh
@@ -56,7 +56,7 @@ function clean_up(){
     fi
 
     if [[ -e "$PATH_TO_LOCAL_OPERATOR_MANIFEST" ]]; then
-        rm --verbose "$PATH_TO_LOCAL_OPERATOR_MANIFEST"
+        rm -v "$PATH_TO_LOCAL_OPERATOR_MANIFEST"
     fi
 
     # the kubectl process does the port-forwarding between operator and local ports
@@ -70,7 +70,7 @@ function clean_up(){
         if kill "$pid" > /dev/null  2>&1; then
             echo "Kill the kubectl process responsible for port forwarding for minikube so that we can re-use the same ports for forwarding later..."
         fi
-        rm --verbose  "$PATH_TO_PORT_FORWARED_KUBECTL_PID"
+        rm -v  "$PATH_TO_PORT_FORWARED_KUBECTL_PID"
 
     fi
 }
@@ -121,7 +121,7 @@ function deploy_self_built_image() {
     # update the tag in the postgres operator conf
     # since the image with this tag already exists on the machine,
     # docker should not attempt to fetch it from the registry due to imagePullPolicy
-    sed --expression "s/\(image\:.*\:\).*$/\1$TAG/; s/smoke-tested-//" manifests/postgres-operator.yaml > "$PATH_TO_LOCAL_OPERATOR_MANIFEST"
+    sed -e "s/\(image\:.*\:\).*$/\1$TAG/; s/smoke-tested-//" manifests/postgres-operator.yaml > "$PATH_TO_LOCAL_OPERATOR_MANIFEST"
 
     retry "kubectl create -f \"$PATH_TO_LOCAL_OPERATOR_MANIFEST\"" "attempt to create $PATH_TO_LOCAL_OPERATOR_MANIFEST resource"
 }


### PR DESCRIPTION
LoadBalancer services in bare metal configuration usually requires some annotations to overcome problem assigning external IP. This should help with that. 