### PR TITLE
Fix run operator locally

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -10,7 +10,7 @@ data:
 
   debug_logging: "true"
   workers: "4"
-  docker_image: registry.opensource.zalan.do/acid/spilo-cdp-11:1.5-p42
+  docker_image: registry.opensource.zalan.do/acid/spilo-11:1.5-p4
   pod_service_account_name: "zalando-postgres-operator"
   secret_name_template: '{username}.{cluster}.credentials'
   super_username: postgres

--- a/manifests/minimal-postgres-manifest.yaml
+++ b/manifests/minimal-postgres-manifest.yaml
@@ -2,7 +2,7 @@ apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
   name: acid-minimal-cluster
-  namespace: test # assumes namespace exists beforehand
+  namespace: default 
 spec:
   teamId: "ACID"
   volume:

--- a/manifests/postgres-operator.yaml
+++ b/manifests/postgres-operator.yaml
@@ -12,7 +12,7 @@ spec:
       serviceAccountName: zalando-postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/smoke-tested-postgres-operator:v1.0.0-21-ge39915c
+        image: registry.opensource.zalan.do/acid/smoke-tested-postgres-operator:v1.0.0-37-g2422d72
         imagePullPolicy: IfNotPresent
         resources:
           requests:


### PR DESCRIPTION

1. Bump up Spilo and operator images
2. Run `acid-minimal-cluster` in the `default` namespace, add an option to run it in `test`
3. Fix the command for starting minikube (caused by changes in its API)
4. Add an option to replace the operator image without restarting the minikube; that greatly speeds up local testing as minikube restarts may take minutes.