### PR TITLE
Correctly report success in .status on Update

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -494,7 +494,7 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 	defer func() {
 		if updateFailed {
 			c.setStatus(acidv1.ClusterStatusUpdateFailed)
-		} else if c.Status != acidv1.ClusterStatusRunning {
+		} else {
 			c.setStatus(acidv1.ClusterStatusRunning)
 		}
 	}()


### PR DESCRIPTION
Problem is in  these 2 lines:

```go
c.setStatus(acidv1.ClusterStatusUpdating)
c.setSpec(newSpec)
```

former sets status in Kubernetes object and `c.Status` via embedded `acidv1.Postgresql`, but llatter one reverts `c.Status` to the one from Event, which for healthy cluster is `acidv1.ClusterStatusRunning` as a result c.Postgresql doesn't reflect latest known state of the object anymore.

When Update() finishes it's job it was  checking c.Status presumably to avoid unnecessary updates, which makes it skip updating status in Kubernetes.

Fixes https://github.com/zalando-incubator/postgres-operator/issues/467